### PR TITLE
feat: switch modules off without removing them from composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Total affected: 3
 - [Defining a module](#defining-a-module)
 - [Extending existing modules](#extending-existing-modules)
 - [Extending the framework](#extending-the-framework)
+- [Switching modules off](#switching-modules-off)
 - [Production notes](#production-notes)
 - [Install](#install)
 - [Documentation](#documentation)
@@ -298,6 +299,57 @@ Macros are normally invisible to static analysis — but the companion
 mixins this package registers, so you extend modules without patching them **and** keep a green
 analysis. See [docs/model-extensions.md](docs/model-extensions.md).
 
+## Switching modules off
+
+A module you are not ready to ship should stay in the repository and stop booting — not disappear from
+`composer.json`. Removing it there leaves the directory on disk while its PSR-4 mapping vanishes, so
+the first symptom is a bare `class not found` from somewhere unrelated.
+
+Two channels decide what boots, and they are **never merged** — the environment key wins whenever it is
+set, even to an empty string:
+
+```bash
+MODULES_DISABLED=acme/workflows      # production, CI, containers; no rebuild needed
+```
+
+```json
+// modules.json in the application root — gitignore it
+{ "disabled": ["acme/workflows"] }
+```
+
+Filtering happens in the package manifest, so a disabled module loses its **service providers and its
+facade aliases together**: no config merge, no routes, no migrations, no scheduled tasks, no panel
+plugins. With an empty list the manifest is returned untouched and the module registry is never read,
+so an application that configures neither channel behaves exactly as before.
+
+A module can declare two things about itself in its own `composer.json`:
+
+```json
+"extra": {
+    "true-modular": {
+        "disablable": false,
+        "owns": ["acme/workflow-engine"]
+    }
+}
+```
+
+`disablable: false` marks a module that must never be switched off (set it on your core module).
+`owns` lists vendor packages this module is the sole owner of — they leave discovery with it, so
+disabling a wrapper doesn't leave the wrapped engine booting its own provider and migrations.
+
+Disabling **never cascades**: switching off a module an enabled module depends on is an error that
+lists exactly what to add. Computing a cascade belongs to a user interface that can ask for
+confirmation; what reaches the runtime is always an explicit, complete list.
+
+```bash
+php artisan module:check              # run this on deploy, before serving traffic
+php artisan module:list --only-disabled
+```
+
+`module:check` also catches the orphaned-directory failure above — a module directory that no
+`composer.json` requires — turning it into one sentence instead of a missing class.
+See [Switching modules off](docs/switching-modules-off.md) for the full reference.
+
 ## Install
 
 ```bash
@@ -326,6 +378,7 @@ Full documentation lives in [`docs/`](docs/README.md):
 | [Module builders](docs/builders.md) | The fluent `Module` API and every feature. |
 | [Lifecycle hooks & schemas](docs/schema-hooks.md) | Overridable provider hooks; report JSON schema. |
 | [Config merging](docs/config-merging.md) | The four config strategies and merge semantics. |
+| [Switching modules off](docs/switching-modules-off.md) | Keep a module in the repo without booting it. |
 | [Best practices](docs/best-practices.md) · [Anti-patterns](docs/anti-patterns.md) | Do's and don'ts. |
 | [Extending the package](docs/extending-the-package.md) | Add features, renderers, sources. |
 | [Testing](docs/testing.md) | Fixtures, helpers, patterns. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Documentation for `happenv-com/laravel-true-modular` — a modular-monolith tool
 - [Architecture & runtime](architecture-runtime.md) — register → initialize → boot; the analysis layer.
 - [Module dependencies](module-dependencies.md) — discovery, topological order, cycles, sorting.
 - [CLI commands](cli-commands.md) — `module:graph` / `module:impact` / `module:why` / `module:list`.
+- [Switching modules off](switching-modules-off.md) — keep a module in the repo without booting it.
 
 ## Working with the package
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -88,7 +88,8 @@ message rather than producing empty output. Renderers are resolved from the cont
 | --- | --- |
 | `true-modular:setup` | Interactively prepare the app to run as a modular monolith (see below). |
 | `module:make {name}` | Scaffold a new module under the configured directory/namespace (see below). |
-| `module:list` | List modules in dependency order (`--reverse`, `--simple`, `--format=table\|text\|json`). |
+| `module:list` | List modules in dependency order (`--reverse`, `--simple`, `--only-disabled`, `--format=table\|text\|json`). |
+| `module:check` | Validate module activation: orphaned directories, the disabled list, dependencies, owned packages. |
 | `module:seed` | Seed module database seeders in dependency order (`--module`, `--class`, `--show-order`). |
 | `module:make:migration {module} {name}` | Scaffold a migration inside a module (`--create`, `--table`). |
 
@@ -97,6 +98,22 @@ dependencies and its path on disk. With `--reverse` the order is flipped (depend
 matches teardown ordering. The default `table` view uses the interactive console table; `--simple`
 (or `--format=text`) prints a plain numbered list and `--format=json` emits the schema-wrapped
 `modules` report — both flow through the same renderer pipeline as the analysis commands.
+
+`--only-disabled` narrows the list to the modules the current environment switches off, and every
+view carries an activation state (a `Status` column in the table, an `enabled` flag in JSON).
+
+### `module:check`
+
+Validates module activation and exits non-zero on the first problem set:
+
+1. every module directory is required by *some* `composer.json` — the root's or another module's;
+2. the disabled list names only known modules;
+3. no disabled module declares `disablable: false`;
+4. no enabled module depends on a disabled one, and no `owns` entry is contested.
+
+Run it on deploy, before the process starts serving — a bad disabled list must abort the release, not
+surface as a missing class on the first request. See
+[Switching modules off](switching-modules-off.md).
 
 ### `true-modular:setup`
 

--- a/docs/switching-modules-off.md
+++ b/docs/switching-modules-off.md
@@ -1,0 +1,128 @@
+# Switching modules off
+
+A module you are not ready to ship should stay in the repository and stop booting — not disappear from
+`composer.json`. Removing it there leaves the directory on disk while its PSR-4 mapping vanishes, so
+the first symptom is a bare `class not found` from somewhere unrelated (typically a test runner that
+globs `app-modules/*/tests`).
+
+The package therefore treats activation as its own concern: the code stays installed, and the
+application decides which modules reach discovery.
+
+## Two channels, one precedence rule
+
+| channel | form | intended user |
+| --- | --- | --- |
+| `MODULES_DISABLED` | comma-separated list, e.g. `acme/workflows,acme/beta` | production and CI — a real environment variable, so it works in a container and needs no rebuild |
+| `modules.json` | `{"disabled": ["acme/workflows"]}` in the application root | a developer machine; gitignore it |
+
+**The environment key wins, and the lists are never merged.**
+
+- `MODULES_DISABLED` set — *even to an empty string* — IS the whole list;
+- otherwise `modules.json`, if present, IS the whole list;
+- otherwise nothing is disabled.
+
+Merging would make the effective state a function of two sources read together, and would take away
+the ability to switch a module back **on** from the environment during an incident. `module:check`
+prints which channel is in effect.
+
+Names may be written bare (`workflows`) or fully qualified (`acme/workflows`); bare names are
+qualified with your default vendor, exactly as in `module:graph` and friends. A name that resolves to
+no known module is an **error**, not a silent no-op — a typo must not quietly disable nothing.
+
+> **Trap:** `MODULES_DISABLED` read from a `.env` **file** is ignored when the configuration is
+> cached — Laravel's `LoadEnvironmentVariables` bootstrapper exits early and never reads `.env`. Real
+> environment variables (the container case) always work.
+
+## What a disabled module loses
+
+The manifest filter runs in `PackageManifest::getManifest()`, so a disabled package is cut from
+discovery whole: its **service providers and its facade aliases** go together. Filtering only
+providers would leave a dangling alias behind.
+
+With no provider registered, the module contributes nothing — no config merge, no routes, no
+migrations, no scheduled tasks, no panel plugins. Its tables stay in the schema with their data;
+switching the module back on later simply runs the migrations it missed.
+
+Nothing is disabled by default, and when the disabled list is empty the filter returns the manifest
+untouched without ever reading the module registry — an application that configures neither channel
+behaves exactly as it did before this feature existed.
+
+## Module declarations
+
+Two optional keys in the **module's** `composer.json`. They live there, rather than in the fluent
+`Module` builder, because they are read before any service provider has registered.
+
+```json
+{
+    "name": "acme/workflows",
+    "type": "true-module",
+    "extra": {
+        "true-modular": {
+            "disablable": false,
+            "owns": ["acme/workflow-engine"]
+        }
+    }
+}
+```
+
+### `disablable` (default `true`)
+
+A module's statement about itself: `false` means it must never be switched off. Set it on your core
+module. Formally it is redundant with the dependency rule below — everything requires core — but it
+turns a cascade of dependency errors into one sentence.
+
+### `owns`
+
+Vendor packages this module is the **sole** owner of. They leave discovery together with the module.
+
+Without this, disabling a module that wraps a third-party package leaves that package's own
+auto-discovered provider booting: its migrations still run, its config still merges, its facade is
+still aliased. The wrapper is off and the engine is on.
+
+`extra.laravel.dont-discover` does not solve this. It is unconditional, so switching the module back
+on in development would leave the engine undiscovered and the module subtly broken. `owns` is coupled
+to the module's own state.
+
+`module:check` rejects an `owns` entry that an **enabled** module (or the root application) also
+requires — a contested package is not owned exclusively.
+
+## Disabling never cascades
+
+Switching off a module that an enabled module depends on is an **error**, listing exactly what to add:
+
+```
+Module [acme/sale] is enabled but depends on disabled [acme/pim]. Add [acme/sale] to the disabled
+list too, or drop [acme/pim] from it — disabling never cascades on its own.
+```
+
+A silent cascade would let one line of configuration switch off a dozen modules with no trace of it
+anywhere. Computing the cascade belongs to a user interface, which can show the affected set and ask
+for confirmation; what reaches the runtime is always an explicit, complete list.
+
+## `module:check`
+
+```bash
+php artisan module:check
+```
+
+Four validations:
+
+1. every module directory is required by *some* `composer.json` — the root's or another module's
+   (this is the orphaned-directory failure described at the top);
+2. the disabled list names only known modules;
+3. no disabled module declares `disablable: false`;
+4. no enabled module depends on a disabled one, and no `owns` entry is contested.
+
+Exit code 0 with a one-line summary, or 1 with one line per problem.
+
+**Run it on deploy**, before the process starts serving — for example next to `config:cache` in a
+container entrypoint. A bad disabled list must abort the release, not surface as a missing class on
+the first request. Running it in CI as well keeps orphaned module directories from being merged.
+
+## Seeing the state
+
+```bash
+php artisan module:list                   # adds a Status column
+php artisan module:list --only-disabled   # just the switched-off ones
+php artisan module:list --format=json     # each module carries an `enabled` flag
+```

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -53,6 +53,13 @@ downstream module (`->hasModelExtensions(Model::class, Extension::class)`), keep
 pointing from the dependent module to the one that owns the model. Never make a low-level module require
 a high-level one, and never create dependency cycles.
 
+### Switching a module off
+
+Never remove a module from `composer.json` to disable it — the directory survives without its autoload
+mapping and fails as an unrelated `class not found`. Use `MODULES_DISABLED=vendor/module` (production,
+CI) or a gitignored `modules.json` (`{"disabled": [...]}`); the environment key wins and the two are
+never merged. Disabling never cascades — validate with `php artisan module:check`.
+
 ### Inspect the architecture
 
 Use `php artisan module:list`, `module:graph`, `module:impact <module>`, and `module:why <from> <to>`

--- a/resources/boost/skills/modular-monolith-development/SKILL.md
+++ b/resources/boost/skills/modular-monolith-development/SKILL.md
@@ -200,6 +200,30 @@ When editing module `X`, work this loop to stay scoped:
    reference to a module not in `require` (or a new cycle) fails analysis — declare the dependency or
    don't cross the boundary.
 
+## Switching a module off
+
+A module that must not boot stays in `composer.json` and in the repository; **never** remove it from
+`require` to disable it (the directory survives, its autoload mapping does not, and the failure shows
+up as an unrelated `class not found`).
+
+```bash
+MODULES_DISABLED=acme/workflows   # production/CI; wins over modules.json, never merged with it
+```
+
+```json
+// modules.json in the application root, gitignored — the developer-machine channel
+{ "disabled": ["acme/workflows"] }
+```
+
+A disabled module loses its providers **and** its facade aliases; it contributes no config, routes,
+migrations or scheduled tasks. In its own `composer.json` a module may declare
+`extra.true-modular.disablable: false` (never switch me off) and `extra.true-modular.owns`
+(vendor packages that leave discovery with me — otherwise a wrapped engine keeps booting its own
+provider).
+
+Disabling never cascades: switching off a module an enabled one depends on is an error naming what to
+add. Validate with `php artisan module:check`, and run it on deploy before serving traffic.
+
 ## Do / don't
 
 - DO put feature code in a module; DON'T add it to `app/`.
@@ -209,6 +233,7 @@ When editing module `X`, work this loop to stay scoped:
 - DO extend other modules' models from the downstream side; DON'T point a dependency upstream or create
   a cycle.
 - DON'T edit package internals to add a renderer/source/feature — use the documented extension seams.
+- DO switch a module off with `MODULES_DISABLED` / `modules.json`; DON'T remove it from `composer.json`.
 
 ## Deeper reference
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Happenv\LaravelTrueModular;
 
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleAwarePackageManifest;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleName;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\CircularDependencyException;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application as FoundationApplication;
+use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use Override;
@@ -99,6 +104,34 @@ final class Application extends FoundationApplication
         }
 
         return $provider;
+    }
+
+    /**
+     * Bind the module-aware package manifest, so a disabled module's providers and
+     * facade aliases never reach discovery in the first place.
+     *
+     * ModuleRegistry is bound here too — earlier than KernelServiceProvider can,
+     * since the manifest decides which providers get registered at all — so the
+     * manifest, the provider sorter and the console commands share ONE instance
+     * and the module scan happens once per process.
+     */
+    #[Override]
+    protected function registerBaseBindings(): void
+    {
+        parent::registerBaseBindings();
+
+        $this->singletonIf(ModuleRegistry::class, static fn (): ModuleRegistry => ModuleRegistry::make());
+
+        $this->singleton(PackageManifest::class, fn (): PackageManifest => new ModuleAwarePackageManifest(
+            new Filesystem,
+            $this->basePath(),
+            $this->getCachedPackagesPath(),
+            fn (): ModuleActivation => new ModuleActivation(
+                $this->make(ModuleRegistry::class),
+                $this->basePath(),
+                self::getModulesVendor(),
+            ),
+        ));
     }
 
     /**

--- a/src/Architecture/Report/ModulesReport.php
+++ b/src/Architecture/Report/ModulesReport.php
@@ -7,7 +7,7 @@ namespace Happenv\LaravelTrueModular\Architecture\Report;
 final readonly class ModulesReport implements ArchitectureReport
 {
     /**
-     * @param  list<array{name: string, dependencies: array<string>, path: string}>  $modules  in resolution order
+     * @param  list<array{name: string, dependencies: array<string>, path: string, enabled: bool}>  $modules  in resolution order
      */
     public function __construct(
         public array $modules,

--- a/src/Commands/ListModulesCommand.php
+++ b/src/Commands/ListModulesCommand.php
@@ -12,6 +12,7 @@ use Happenv\LaravelTrueModular\Architecture\Renderer\RenderContext;
 use Happenv\LaravelTrueModular\Architecture\Renderer\RendererRegistry;
 use Happenv\LaravelTrueModular\Architecture\Report\ModulesReport;
 use Happenv\LaravelTrueModular\ModuleSystem\Exceptions\CircularDependencyException;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
 use Illuminate\Console\Command;
 use InvalidArgumentException;
@@ -24,7 +25,8 @@ class ListModulesCommand extends Command
                             {--reverse : Show in reverse dependency order (dependents first)}
                             {--simple : Show simple list without table}
                             {--format= : Output format (table, text, json)}
-                            {--with-vendor : Show full vendor/name even for local modules}';
+                            {--with-vendor : Show full vendor/name even for local modules}
+                            {--only-disabled : Show only the modules this environment switches off}';
 
     protected $description = 'List all modules in dependency order';
 
@@ -42,7 +44,7 @@ class ListModulesCommand extends Command
      * @throws InvalidArgumentException
      * @throws JsonException
      */
-    public function handle(): int
+    public function handle(ModuleActivation $activation): int
     {
         try {
             $order = $this->option('reverse')
@@ -67,9 +69,9 @@ class ListModulesCommand extends Command
         // The boxed table is an interactive console view (Symfony table component),
         // so it stays here; every string format flows through the renderer registry.
         if ($format === 'table') {
-            return $this->showTable($order, $index, $context);
+            return $this->showTable($this->rows($order, $index, $activation), $context);
         }
-        $report = new ModulesReport($this->rows($order, $index), (bool) $this->option('reverse'));
+        $report = new ModulesReport($this->rows($order, $index, $activation), (bool) $this->option('reverse'));
         $rendered = $this->renderers->get($format, $report)->render($report, $context);
 
         foreach (explode("\n", $rendered) as $line) {
@@ -91,11 +93,11 @@ class ListModulesCommand extends Command
     }
 
     /**
-     * @param  array<string>  $order
+     * @param  list<array{name: string, dependencies: array<string>, path: string, enabled: bool}>  $rows
      *
      * @throws InvalidArgumentException
      */
-    private function showTable(array $order, ArchitectureIndex $index, RenderContext $context): int
+    private function showTable(array $rows, RenderContext $context): int
     {
         $direction = $this->option('reverse') ? 'dependents first' : 'dependencies first';
         $this->components->info(sprintf('Modules (%s):', $direction));
@@ -103,7 +105,7 @@ class ListModulesCommand extends Command
 
         $tableData = [];
 
-        foreach ($this->rows($order, $index) as $position => $row) {
+        foreach ($rows as $position => $row) {
             $dependencies = array_map(
                 static fn (string $dependency): string => $context->display($dependency),
                 $row['dependencies'],
@@ -112,38 +114,51 @@ class ListModulesCommand extends Command
             $tableData[] = [
                 $position + 1,
                 $context->display($row['name']),
+                $row['enabled'] ? 'enabled' : 'disabled',
                 $dependencies !== [] ? implode(PHP_EOL, $dependencies) : '-',
                 $row['path'],
             ];
 
-            $tableData[] = ['-', '-', '-', '-'];
+            $tableData[] = ['-', '-', '-', '-', '-'];
         }
 
-        $this->table(['#', 'Module', 'Depends On', 'Path'], $tableData);
+        $this->table(['#', 'Module', 'Status', 'Depends On', 'Path'], $tableData);
 
-        $this->components->info(sprintf('Total: %d modules', count($order)));
+        $this->components->info(sprintf('Total: %d modules', count($rows)));
 
         return self::SUCCESS;
     }
 
     /**
      * Build ordered rows sourced from the architecture index (dependencies and
-     * path), keeping a single description of each module's data.
+     * path) and the activation state, keeping a single description of each
+     * module's data.
      *
      * @param  array<string>  $order
-     * @return list<array{name: string, dependencies: array<string>, path: string}>
+     * @return list<array{name: string, dependencies: array<string>, path: string, enabled: bool}>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
      */
-    private function rows(array $order, ArchitectureIndex $index): array
+    private function rows(array $order, ArchitectureIndex $index, ModuleActivation $activation): array
     {
+        $onlyDisabled = (bool) $this->option('only-disabled');
         $rows = [];
 
         foreach ($order as $moduleName) {
+            $enabled = ! $activation->isDisabled($moduleName);
+
+            if ($onlyDisabled && $enabled) {
+                continue;
+            }
+
             $descriptor = $index->module($moduleName);
 
             $rows[] = [
                 'name' => $moduleName,
                 'dependencies' => $index->graph()->dependencies($moduleName),
                 'path' => $descriptor instanceof ModuleDescriptor ? str_replace(base_path().'/', '', $descriptor->path) : '',
+                'enabled' => $enabled,
             ];
         }
 

--- a/src/Commands/ModuleCheckCommand.php
+++ b/src/Commands/ModuleCheckCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\Commands;
+
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivationAudit;
+use Illuminate\Console\Command;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\JsonException;
+
+/**
+ * Validates module activation.
+ *
+ * Run it on deploy, before the process starts serving: a bad disabled list must
+ * abort the release, not surface as a missing class on the first request.
+ */
+final class ModuleCheckCommand extends Command
+{
+    protected $signature = 'module:check';
+
+    protected $description = 'Validate module activation: installed modules, the disabled list, dependencies and owned packages';
+
+    /**
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function handle(ModuleActivationAudit $audit, ModuleActivation $activation): int
+    {
+        $problems = $audit->problems();
+
+        if ($problems !== []) {
+            foreach ($problems as $problem) {
+                $this->components->error($problem);
+            }
+
+            return self::FAILURE;
+        }
+
+        $disabled = $activation->disabled();
+
+        $this->components->info($disabled === []
+            ? 'All modules enabled.'
+            : sprintf('Disabled via %s: %s', $activation->channel(), implode(', ', $disabled)));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/KernelServiceProvider.php
+++ b/src/KernelServiceProvider.php
@@ -20,12 +20,15 @@ use Happenv\LaravelTrueModular\Architecture\Source\ComposerArchitectureSource;
 use Happenv\LaravelTrueModular\Commands\ListModulesCommand;
 use Happenv\LaravelTrueModular\Commands\MakeMigrationCommand;
 use Happenv\LaravelTrueModular\Commands\MakeModuleCommand;
+use Happenv\LaravelTrueModular\Commands\ModuleCheckCommand;
 use Happenv\LaravelTrueModular\Commands\ModuleGraphCommand;
 use Happenv\LaravelTrueModular\Commands\ModuleImpactCommand;
 use Happenv\LaravelTrueModular\Commands\ModuleWhyCommand;
 use Happenv\LaravelTrueModular\Commands\SeedModulesCommand;
 use Happenv\LaravelTrueModular\Commands\SetupCommand;
 use Happenv\LaravelTrueModular\Generators\ModuleGenerator;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivationAudit;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleFileFinder;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleManifestRepository;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
@@ -50,6 +53,7 @@ class KernelServiceProvider extends ServiceProvider
                 SetupCommand::class,
                 MakeModuleCommand::class,
                 ListModulesCommand::class,
+                ModuleCheckCommand::class,
                 SeedModulesCommand::class,
                 MakeMigrationCommand::class,
                 ModuleImpactCommand::class,
@@ -85,6 +89,17 @@ class KernelServiceProvider extends ServiceProvider
         $this->app->singleton(ModuleFileFinder::class, static fn ($app): ModuleFileFinder => new ModuleFileFinder(
             $app->make(ModuleRegistry::class)
         ));
+
+        $this->app->singletonIf(ModuleActivation::class, static fn (): ModuleActivation => ModuleActivation::make());
+
+        $this->app->singleton(
+            ModuleActivationAudit::class,
+            static fn (Application $app): ModuleActivationAudit => new ModuleActivationAudit(
+                $app->make(ModuleRegistry::class),
+                $app->make(ModuleActivation::class),
+                $app->basePath(),
+            ),
+        );
 
         $this->app->singleton(
             ModuleLocator::class,

--- a/src/KernelServiceProvider.php
+++ b/src/KernelServiceProvider.php
@@ -77,7 +77,10 @@ class KernelServiceProvider extends ServiceProvider
             $app->basePath(),
         ));
 
-        $this->app->singleton(ModuleRegistry::class, static fn (): ModuleRegistry => ModuleRegistry::make());
+        // singletonIf, not singleton: under our own Application the registry is already
+        // bound in registerBaseBindings(), and rebinding would discard its memoized
+        // module scan. Under the stock Illuminate Application this still binds.
+        $this->app->singletonIf(ModuleRegistry::class, static fn (): ModuleRegistry => ModuleRegistry::make());
 
         $this->app->singleton(ModuleFileFinder::class, static fn ($app): ModuleFileFinder => new ModuleFileFinder(
             $app->make(ModuleRegistry::class)

--- a/src/ModuleSystem/ModuleActivation.php
+++ b/src/ModuleSystem/ModuleActivation.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\ModuleSystem;
+
+use Happenv\LaravelTrueModular\Application;
+use Illuminate\Support\Env;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\JsonException;
+
+use function Safe\file_get_contents;
+use function Safe\json_decode;
+
+/**
+ * The single reader of module activation state.
+ *
+ * Two channels, one precedence rule and NO merging: when the environment key is
+ * set — even to an empty string — it IS the whole list; otherwise `modules.json`
+ * is the whole list; otherwise nothing is disabled. Merging would make the
+ * effective state a function of two sources read together, and would remove the
+ * ability to switch a module back ON from the environment.
+ */
+final class ModuleActivation
+{
+    public const string ENV_KEY = 'MODULES_DISABLED';
+
+    public const string FILE_NAME = 'modules.json';
+
+    /** @var list<string>|null */
+    private ?array $disabled = null;
+
+    private ?string $channel = null;
+
+    public function __construct(
+        private readonly ModuleRegistry $registry,
+        private readonly string $basePath,
+        private readonly string $vendor,
+    ) {}
+
+    public static function make(): self
+    {
+        return new self(
+            ModuleRegistry::make(),
+            base_path(),
+            Application::getModulesVendor(),
+        );
+    }
+
+    /**
+     * Fully qualified names of the modules that must not be activated.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function disabled(): array
+    {
+        $this->resolve();
+
+        return $this->disabled ?? [];
+    }
+
+    /**
+     * Which channel produced the current list: `env`, `file` or `none`.
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function channel(): string
+    {
+        $this->resolve();
+
+        return $this->channel ?? 'none';
+    }
+
+    /**
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function isDisabled(string $moduleName): bool
+    {
+        return in_array(ModuleName::qualify($moduleName, $this->vendor), $this->disabled(), true);
+    }
+
+    /**
+     * Whether the module allows being switched off at all. Declared by the module
+     * itself in `extra.true-modular.disablable`; defaults to true.
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function isDisablable(string $moduleName): bool
+    {
+        return ($this->extra($moduleName)['disablable'] ?? true) !== false;
+    }
+
+    /**
+     * Vendor packages the module declares itself the sole owner of. They leave
+     * discovery together with the module — otherwise a package carrying its own
+     * auto-discovered provider keeps booting after the module is switched off.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function owns(string $moduleName): array
+    {
+        $owns = $this->extra($moduleName)['owns'] ?? [];
+
+        return is_array($owns)
+            ? array_values(array_filter($owns, is_string(...)))
+            : [];
+    }
+
+    /**
+     * Composer package names to drop from the discovery manifest.
+     *
+     * Returns early when nothing is disabled, so the common case never reads the
+     * module registry — which scans every module's composer.json.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function excludedPackages(): array
+    {
+        $disabled = $this->disabled();
+
+        if ($disabled === []) {
+            return [];
+        }
+
+        $excluded = $disabled;
+
+        foreach ($disabled as $moduleName) {
+            foreach ($this->owns($moduleName) as $package) {
+                $excluded[] = $package;
+            }
+        }
+
+        return array_values(array_unique($excluded));
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function extra(string $moduleName): array
+    {
+        $qualified = ModuleName::qualify($moduleName, $this->vendor);
+        $extra = $this->registry->getAllModules()[$qualified]['composer']['extra']['true-modular'] ?? [];
+
+        return is_array($extra) ? $extra : [];
+    }
+
+    /**
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function resolve(): void
+    {
+        if ($this->disabled !== null) {
+            return;
+        }
+
+        $fromEnv = Env::get(self::ENV_KEY);
+
+        if (is_string($fromEnv)) {
+            $this->channel = 'env';
+            $this->disabled = $this->qualifyAll(explode(',', $fromEnv));
+
+            return;
+        }
+
+        $path = $this->basePath.DIRECTORY_SEPARATOR.self::FILE_NAME;
+
+        if (is_file($path)) {
+            $decoded = json_decode(file_get_contents($path), associative: true);
+            $listed = is_array($decoded) ? ($decoded['disabled'] ?? []) : [];
+
+            $this->channel = 'file';
+            $this->disabled = $this->qualifyAll(is_array($listed) ? $listed : []);
+
+            return;
+        }
+
+        $this->channel = 'none';
+        $this->disabled = [];
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $names
+     * @return list<string>
+     */
+    private function qualifyAll(array $names): array
+    {
+        $qualified = [];
+
+        foreach ($names as $name) {
+            if (! is_string($name)) {
+                continue;
+            }
+
+            $name = trim($name);
+
+            if ($name === '') {
+                continue;
+            }
+
+            $qualified[] = ModuleName::qualify($name, $this->vendor);
+        }
+
+        return array_values(array_unique($qualified));
+    }
+}

--- a/src/ModuleSystem/ModuleActivationAudit.php
+++ b/src/ModuleSystem/ModuleActivationAudit.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\ModuleSystem;
+
+use Happenv\LaravelTrueModular\Application;
+use Safe\Exceptions\FilesystemException;
+use Safe\Exceptions\JsonException;
+
+use function Safe\file_get_contents;
+use function Safe\json_decode;
+
+/**
+ * Validates module activation state.
+ *
+ * Reports problems instead of throwing, so the caller decides the consequence:
+ * the console command exits non-zero, the deploy entrypoint aborts the container,
+ * a test asserts an empty list.
+ */
+final class ModuleActivationAudit
+{
+    public function __construct(
+        private readonly ModuleRegistry $registry,
+        private readonly ModuleActivation $activation,
+        private readonly string $basePath,
+    ) {}
+
+    /**
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    public function problems(): array
+    {
+        return [
+            ...$this->orphanedModules(),
+            ...$this->unknownOrProtectedDisables(),
+            ...$this->brokenDependencies(),
+            ...$this->contestedOwnedPackages(),
+        ];
+    }
+
+    /**
+     * A module directory nobody requires is the failure this whole feature exists
+     * to make legible: its classes stop autoloading while its files stay on disk,
+     * so the first symptom is a bare "class not found" from an unrelated place.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function orphanedModules(): array
+    {
+        $modules = $this->registry->getAllModules();
+        $declared = $this->requirements($this->rootComposer());
+
+        foreach ($modules as $module) {
+            $declared = [...$declared, ...$this->requirements($module['composer'])];
+        }
+
+        $declared = array_flip($declared);
+        $problems = [];
+
+        foreach (array_keys($modules) as $name) {
+            if (isset($declared[$name])) {
+                continue;
+            }
+
+            $problems[] = sprintf(
+                'Module [%s] sits in %s/ but no composer.json requires it, so its classes will not autoload. '
+                    .'Add it back to the root require, or delete the directory. To switch a module OFF, use %s or %s.',
+                $name,
+                Application::getModulesDirectory(),
+                ModuleActivation::ENV_KEY,
+                ModuleActivation::FILE_NAME,
+            );
+        }
+
+        return $problems;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function unknownOrProtectedDisables(): array
+    {
+        $modules = $this->registry->getAllModules();
+        $channel = $this->activation->channel();
+        $problems = [];
+
+        foreach ($this->activation->disabled() as $name) {
+            if (! isset($modules[$name])) {
+                $problems[] = sprintf(
+                    'The disabled list names [%s], which is not a known module. Fix the name in %s.',
+                    $name,
+                    $channel === 'env' ? ModuleActivation::ENV_KEY : ModuleActivation::FILE_NAME,
+                );
+
+                continue;
+            }
+
+            if (! $this->activation->isDisablable($name)) {
+                $problems[] = sprintf(
+                    'Module [%s] declares `disablable: false` and must not be switched off.',
+                    $name,
+                );
+            }
+        }
+
+        return $problems;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function brokenDependencies(): array
+    {
+        $disabled = $this->activation->disabled();
+
+        if ($disabled === []) {
+            return [];
+        }
+
+        $disabledNames = array_flip($disabled);
+        $problems = [];
+
+        foreach (array_keys($this->registry->getAllModules()) as $name) {
+            if (isset($disabledNames[$name])) {
+                continue;
+            }
+
+            foreach ($this->registry->getDependencies($name) as $dependency) {
+                if (! isset($disabledNames[$dependency])) {
+                    continue;
+                }
+
+                $problems[] = sprintf(
+                    'Module [%s] is enabled but depends on disabled [%s]. Add [%s] to the disabled list too, '
+                        .'or drop [%s] from it — disabling never cascades on its own.',
+                    $name,
+                    $dependency,
+                    $name,
+                    $dependency,
+                );
+            }
+        }
+
+        return $problems;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function contestedOwnedPackages(): array
+    {
+        $disabled = $this->activation->disabled();
+
+        if ($disabled === []) {
+            return [];
+        }
+
+        $disabledNames = array_flip($disabled);
+        $modules = $this->registry->getAllModules();
+        $problems = [];
+
+        foreach ($disabled as $name) {
+            foreach ($this->activation->owns($name) as $package) {
+                foreach ($this->claimants($package, $modules, $disabledNames) as $claimant) {
+                    $problems[] = sprintf(
+                        'Package [%s] is declared as owned by disabled module [%s], but %s requires it too. '
+                            .'Remove it from the `owns` list — it is not owned exclusively.',
+                        $package,
+                        $name,
+                        $claimant,
+                    );
+                }
+            }
+        }
+
+        return $problems;
+    }
+
+    /**
+     * @param  array<string, array{composer: array<string, mixed>, name: string, path: string}>  $modules
+     * @param  array<string, int>  $disabledNames
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function claimants(string $package, array $modules, array $disabledNames): array
+    {
+        $claimants = [];
+
+        if (in_array($package, $this->requirements($this->rootComposer()), true)) {
+            $claimants[] = 'the root application';
+        }
+
+        foreach ($modules as $name => $module) {
+            if (isset($disabledNames[$name])) {
+                continue;
+            }
+
+            if (in_array($package, $this->requirements($module['composer']), true)) {
+                $claimants[] = sprintf('enabled module [%s]', $name);
+            }
+        }
+
+        return $claimants;
+    }
+
+    /**
+     * @param  array<string, mixed>  $composer
+     * @return list<string>
+     */
+    private function requirements(array $composer): array
+    {
+        $require = is_array($composer['require'] ?? null) ? $composer['require'] : [];
+        $requireDev = is_array($composer['require-dev'] ?? null) ? $composer['require-dev'] : [];
+
+        return array_values(array_map(strval(...), array_keys($require + $requireDev)));
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function rootComposer(): array
+    {
+        $path = $this->basePath.'/composer.json';
+
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $decoded = json_decode(file_get_contents($path), associative: true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/src/ModuleSystem/ModuleActivationAudit.php
+++ b/src/ModuleSystem/ModuleActivationAudit.php
@@ -230,7 +230,7 @@ final class ModuleActivationAudit
         $require = is_array($composer['require'] ?? null) ? $composer['require'] : [];
         $requireDev = is_array($composer['require-dev'] ?? null) ? $composer['require-dev'] : [];
 
-        return array_values(array_map(strval(...), array_keys($require + $requireDev)));
+        return array_map(strval(...), array_keys($require + $requireDev));
     }
 
     /**

--- a/src/ModuleSystem/ModuleAwarePackageManifest.php
+++ b/src/ModuleSystem/ModuleAwarePackageManifest.php
@@ -24,8 +24,8 @@ final class ModuleAwarePackageManifest extends PackageManifest
 
     /**
      * @param  Closure(): ModuleActivation  $activationResolver  resolved lazily: the manifest is
-     *                                                          built during RegisterProviders, before the package's own
-     *                                                          service provider has bound anything.
+     *                                                           built during RegisterProviders, before the package's own
+     *                                                           service provider has bound anything.
      */
     public function __construct(
         Filesystem $files,

--- a/src/ModuleSystem/ModuleAwarePackageManifest.php
+++ b/src/ModuleSystem/ModuleAwarePackageManifest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\ModuleSystem;
+
+use Closure;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\PackageManifest;
+use Override;
+
+/**
+ * Removes disabled modules — and the vendor packages they own — from Laravel's
+ * package discovery manifest.
+ *
+ * Filtering happens in getManifest() rather than in providers(), because a
+ * package cut there loses its service providers AND its facade aliases in one
+ * move; filtering providers() alone would leave a dangling alias behind.
+ */
+final class ModuleAwarePackageManifest extends PackageManifest
+{
+    /** @var array<string, mixed>|null */
+    private ?array $filteredManifest = null;
+
+    /**
+     * @param  Closure(): ModuleActivation  $activationResolver  resolved lazily: the manifest is
+     *                                                          built during RegisterProviders, before the package's own
+     *                                                          service provider has bound anything.
+     */
+    public function __construct(
+        Filesystem $files,
+        string $basePath,
+        string $manifestPath,
+        private readonly Closure $activationResolver,
+    ) {
+        parent::__construct($files, $basePath, $manifestPath);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
+    protected function getManifest(): array
+    {
+        if ($this->filteredManifest !== null) {
+            return $this->filteredManifest;
+        }
+
+        /** @var array<string, mixed> $manifest */
+        $manifest = parent::getManifest();
+
+        $excluded = ($this->activationResolver)()->excludedPackages();
+
+        return $this->filteredManifest = $excluded === []
+            ? $manifest
+            : array_diff_key($manifest, array_flip($excluded));
+    }
+}

--- a/tests/Feature/ListModulesCommandTest.php
+++ b/tests/Feature/ListModulesCommandTest.php
@@ -6,6 +6,7 @@ use Happenv\LaravelTrueModular\Application;
 use Happenv\LaravelTrueModular\Architecture\Index\ArchitectureIndexBuilder;
 use Happenv\LaravelTrueModular\Architecture\Renderer\RendererRegistry;
 use Happenv\LaravelTrueModular\Commands\ListModulesCommand;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
 use Illuminate\Support\Facades\Artisan;
 
@@ -92,4 +93,48 @@ it('keeps full names in json regardless of vendor', function (): void {
     $this->artisan('module:list', ['--format' => 'json'])
         ->assertSuccessful()
         ->expectsOutputToContain('myapp/core');
+});
+
+describe('activation state', function (): void {
+    afterEach(function (): void {
+        unset($_ENV[ModuleActivation::ENV_KEY], $_SERVER[ModuleActivation::ENV_KEY]);
+    });
+
+    it('reports every module as enabled when no channel disables anything', function (): void {
+        $_ENV[ModuleActivation::ENV_KEY] = '';
+
+        $exit = Artisan::call('module:list', ['--format' => 'json']);
+        $json = json_decode(Artisan::output(), associative: true);
+
+        expect($exit)->toBe(0)
+            ->and(collect($json['modules'])->pluck('enabled')->unique()->all())->toBe([true]);
+    });
+
+    it('marks a disabled module in the json report', function (): void {
+        $_ENV[ModuleActivation::ENV_KEY] = 'myapp/amazon';
+
+        Artisan::call('module:list', ['--format' => 'json']);
+        $json = json_decode(Artisan::output(), associative: true);
+
+        expect(collect($json['modules'])->firstWhere('name', 'myapp/amazon')['enabled'])->toBeFalse()
+            ->and(collect($json['modules'])->firstWhere('name', 'myapp/pim')['enabled'])->toBeTrue();
+    });
+
+    it('shows the state in the table view', function (): void {
+        $_ENV[ModuleActivation::ENV_KEY] = 'myapp/amazon';
+
+        $this->artisan('module:list')
+            ->assertSuccessful()
+            ->expectsOutputToContain('disabled');
+    });
+
+    it('narrows the list to switched-off modules on demand', function (): void {
+        $_ENV[ModuleActivation::ENV_KEY] = 'myapp/amazon';
+
+        Artisan::call('module:list', ['--format' => 'json', '--only-disabled' => true]);
+        $json = json_decode(Artisan::output(), associative: true);
+
+        expect($json['modules'])->toHaveCount(1)
+            ->and($json['modules'][0]['name'])->toBe('myapp/amazon');
+    });
 });

--- a/tests/Feature/ModuleCheckCommandTest.php
+++ b/tests/Feature/ModuleCheckCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+
+afterEach(function (): void {
+    unset($_ENV[ModuleActivation::ENV_KEY], $_SERVER[ModuleActivation::ENV_KEY]);
+});
+
+it('succeeds when the activation state is sound', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = '';
+
+    $this->artisan('module:check')
+        ->expectsOutputToContain('All modules enabled')
+        ->assertSuccessful();
+});
+
+it('fails and names the offending module', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = 'myapp/nope';
+
+    $this->artisan('module:check')
+        ->expectsOutputToContain('myapp/nope')
+        ->assertFailed();
+});
+
+it('reports the channel a sound disabled list came from', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = 'myapp/amazon';
+
+    $this->artisan('module:check')
+        ->expectsOutputToContain('Disabled via env: myapp/amazon')
+        ->assertSuccessful();
+});

--- a/tests/Unit/ApplicationPackageManifestTest.php
+++ b/tests/Unit/ApplicationPackageManifestTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\Application;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleAwarePackageManifest;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
+use Illuminate\Foundation\PackageManifest;
+
+it('binds the module-aware package manifest so disabled modules never reach discovery', function (): void {
+    $app = new Application(dirname(appModulesFixture()));
+
+    expect($app->make(PackageManifest::class))->toBeInstanceOf(ModuleAwarePackageManifest::class);
+});
+
+it('shares one module registry instance across the application', function (): void {
+    $app = new Application(dirname(appModulesFixture()));
+
+    expect($app->make(ModuleRegistry::class))->toBe($app->make(ModuleRegistry::class));
+});

--- a/tests/Unit/ModuleSystem/ModuleActivationAuditTest.php
+++ b/tests/Unit/ModuleSystem/ModuleActivationAuditTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivationAudit;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
+
+function audit(string $envValue): ModuleActivationAudit
+{
+    $_ENV[ModuleActivation::ENV_KEY] = $envValue;
+
+    $registry = new ModuleRegistry(appModulesFixture());
+
+    return new ModuleActivationAudit(
+        $registry,
+        new ModuleActivation($registry, dirname(appModulesFixture()), 'myapp'),
+        dirname(appModulesFixture()),
+    );
+}
+
+afterEach(function (): void {
+    unset($_ENV[ModuleActivation::ENV_KEY], $_SERVER[ModuleActivation::ENV_KEY]);
+});
+
+it('reports no problems when nothing is disabled', function (): void {
+    expect(audit('')->problems())->toBe([]);
+});
+
+it('rejects a name that resolves to no known module', function (): void {
+    $problems = audit('myapp/nope')->problems();
+
+    expect($problems)->toHaveCount(1)
+        ->and($problems[0])->toContain('myapp/nope');
+});
+
+it('rejects disabling a module that declares itself not disablable', function (): void {
+    expect(implode("\n", audit('core')->problems()))->toContain('disablable');
+});
+
+it('rejects leaving an enabled module depending on a disabled one', function (): void {
+    // Fixture graph: kernel <- core <- pim <- sale <- amazon.
+    $problems = implode("\n", audit('pim')->problems());
+
+    expect($problems)->toContain('myapp/sale')
+        ->and($problems)->toContain('myapp/pim');
+});
+
+it('accepts a disabled leaf module, since nothing depends on it', function (): void {
+    expect(audit('amazon')->problems())->toBe([]);
+});
+
+it('accepts a disabled module when every dependent is disabled too', function (): void {
+    expect(audit('myapp/pim,myapp/sale,myapp/amazon')->problems())->toBe([]);
+});
+
+it('never cascades on its own — one entry short is still a problem', function (): void {
+    $problems = implode("\n", audit('myapp/pim,myapp/sale')->problems());
+
+    expect($problems)->toContain('myapp/amazon');
+});

--- a/tests/Unit/ModuleSystem/ModuleActivationTest.php
+++ b/tests/Unit/ModuleSystem/ModuleActivationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
+
+function activation(): ModuleActivation
+{
+    return new ModuleActivation(
+        new ModuleRegistry(appModulesFixture()),
+        dirname(appModulesFixture()),
+        'myapp',
+    );
+}
+
+function activationFile(): string
+{
+    return dirname(appModulesFixture()).'/'.ModuleActivation::FILE_NAME;
+}
+
+afterEach(function (): void {
+    unset($_ENV[ModuleActivation::ENV_KEY], $_SERVER[ModuleActivation::ENV_KEY]);
+    putenv(ModuleActivation::ENV_KEY);
+
+    if (is_file(activationFile())) {
+        unlink(activationFile());
+    }
+});
+
+it('reports nothing disabled when neither channel is present', function (): void {
+    expect(activation()->disabled())->toBe([])
+        ->and(activation()->channel())->toBe('none');
+});
+
+it('reads the env channel and qualifies bare names', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = 'amazon, myapp/pim';
+
+    expect(activation()->disabled())->toBe(['myapp/amazon', 'myapp/pim'])
+        ->and(activation()->channel())->toBe('env');
+});
+
+it('treats an empty env value as an explicit empty list, not as absence', function (): void {
+    file_put_contents(activationFile(), json_encode(['disabled' => ['myapp/amazon']]));
+    $_ENV[ModuleActivation::ENV_KEY] = '';
+
+    expect(activation()->disabled())->toBe([])
+        ->and(activation()->channel())->toBe('env');
+});
+
+it('falls back to modules.json when the env key is absent', function (): void {
+    file_put_contents(activationFile(), json_encode(['disabled' => ['amazon']]));
+
+    expect(activation()->disabled())->toBe(['myapp/amazon'])
+        ->and(activation()->channel())->toBe('file');
+});
+
+it('reads disablable from the module composer.json, defaulting to true', function (): void {
+    expect(activation()->isDisablable('myapp/core'))->toBeFalse()
+        ->and(activation()->isDisablable('core'))->toBeFalse()
+        ->and(activation()->isDisablable('myapp/amazon'))->toBeTrue();
+});
+
+it('excludes a disabled module together with the packages it owns', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = 'amazon';
+
+    expect(activation()->excludedPackages())->toBe(['myapp/amazon', 'myapp/amazon-sdk']);
+});
+
+it('excludes nothing at all when no module is disabled', function (): void {
+    expect(activation()->excludedPackages())->toBe([]);
+});
+
+it('answers isDisabled for both the bare and the qualified name', function (): void {
+    $_ENV[ModuleActivation::ENV_KEY] = 'myapp/amazon';
+
+    expect(activation()->isDisabled('amazon'))->toBeTrue()
+        ->and(activation()->isDisabled('myapp/amazon'))->toBeTrue()
+        ->and(activation()->isDisabled('myapp/pim'))->toBeFalse();
+});

--- a/tests/Unit/ModuleSystem/ModuleAwarePackageManifestTest.php
+++ b/tests/Unit/ModuleSystem/ModuleAwarePackageManifestTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleAwarePackageManifest;
+use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * @param  array<string, mixed>  $manifest
+ */
+function manifestFixture(array $manifest): string
+{
+    $path = sys_get_temp_dir().'/true-modular-manifest-'.uniqid().'.php';
+    file_put_contents($path, '<?php return '.var_export($manifest, true).';');
+
+    return $path;
+}
+
+/**
+ * @param  array<string, mixed>  $manifest
+ */
+function packageManifest(array $manifest, string $envValue): ModuleAwarePackageManifest
+{
+    $_ENV[ModuleActivation::ENV_KEY] = $envValue;
+
+    return new ModuleAwarePackageManifest(
+        new Filesystem,
+        dirname(appModulesFixture()),
+        manifestFixture($manifest),
+        static fn (): ModuleActivation => new ModuleActivation(
+            new ModuleRegistry(appModulesFixture()),
+            dirname(appModulesFixture()),
+            'myapp',
+        ),
+    );
+}
+
+afterEach(function (): void {
+    unset($_ENV[ModuleActivation::ENV_KEY], $_SERVER[ModuleActivation::ENV_KEY]);
+
+    foreach (glob(sys_get_temp_dir().'/true-modular-manifest-*.php') ?: [] as $leftover) {
+        unlink($leftover);
+    }
+});
+
+it('drops the providers and the facade aliases of a disabled module together', function (): void {
+    $manifest = packageManifest([
+        'myapp/amazon' => [
+            'providers' => ['Myapp\Amazon\Provider'],
+            'aliases' => ['Amazon' => 'Myapp\Amazon\Facade'],
+        ],
+        'myapp/pim' => ['providers' => ['Myapp\Pim\Provider']],
+    ], 'amazon');
+
+    expect($manifest->providers())->toBe(['Myapp\Pim\Provider'])
+        ->and($manifest->aliases())->toBe([]);
+});
+
+it('also drops the vendor packages a disabled module declares it owns', function (): void {
+    $manifest = packageManifest([
+        'myapp/amazon' => ['providers' => ['Myapp\Amazon\Provider']],
+        'myapp/amazon-sdk' => ['providers' => ['Myapp\AmazonSdk\Provider']],
+        'myapp/pim' => ['providers' => ['Myapp\Pim\Provider']],
+    ], 'amazon');
+
+    expect($manifest->providers())->toBe(['Myapp\Pim\Provider']);
+});
+
+it('returns the manifest untouched when nothing is disabled', function (): void {
+    $manifest = packageManifest([
+        'myapp/amazon' => ['providers' => ['Myapp\Amazon\Provider']],
+        'myapp/pim' => ['providers' => ['Myapp\Pim\Provider']],
+    ], '');
+
+    expect($manifest->providers())->toBe(['Myapp\Amazon\Provider', 'Myapp\Pim\Provider']);
+});
+
+it('leaves an unrelated package alone when a module is disabled', function (): void {
+    $manifest = packageManifest([
+        'myapp/amazon' => ['providers' => ['Myapp\Amazon\Provider']],
+        'acme/unrelated' => ['providers' => ['Acme\Unrelated\Provider']],
+    ], 'amazon');
+
+    expect($manifest->providers())->toBe(['Acme\Unrelated\Provider']);
+});

--- a/tests/fixtures/app-modules/amazon/composer.json
+++ b/tests/fixtures/app-modules/amazon/composer.json
@@ -1,6 +1,19 @@
 {
     "name": "myapp/amazon",
     "type": "true-module",
-    "require": { "myapp/sale": "*" },
-    "autoload": { "psr-4": { "Myapp\\Amazon\\": "src/" } }
+    "require": {
+        "myapp/sale": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Myapp\\Amazon\\": "src/"
+        }
+    },
+    "extra": {
+        "true-modular": {
+            "owns": [
+                "myapp/amazon-sdk"
+            ]
+        }
+    }
 }

--- a/tests/fixtures/app-modules/core/composer.json
+++ b/tests/fixtures/app-modules/core/composer.json
@@ -2,6 +2,17 @@
     "name": "myapp/core",
     "type": "true-module",
     "version": "1.0.0",
-    "require": { "myapp/kernel": "*" },
-    "autoload": { "psr-4": { "Myapp\\Core\\": "src/" } }
+    "require": {
+        "myapp/kernel": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Myapp\\Core\\": "src/"
+        }
+    },
+    "extra": {
+        "true-modular": {
+            "disablable": false
+        }
+    }
 }

--- a/tests/fixtures/composer.json
+++ b/tests/fixtures/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "myapp/app",
+    "description": "Fixture root application: mirrors a real host that requires its leaf modules and lets Composer pull the rest transitively.",
+    "require": {
+        "myapp/amazon": "*"
+    }
+}


### PR DESCRIPTION
Lets an application keep a module in the repository while stopping it from booting.

Removing a module from `composer.json` to disable it leaves its directory on disk while its PSR-4 mapping vanishes, so the first symptom is a bare `class not found` from somewhere unrelated — typically a test runner globbing `app-modules/*/tests`. Activation becomes its own concern instead.

## Two channels, one precedence rule

| channel | intended user |
| --- | --- |
| `MODULES_DISABLED=acme/workflows` | production, CI, containers — a real env var, no rebuild needed |
| `modules.json` (`{"disabled": [...]}`, gitignored) | developer machines |

The env key wins whenever it is set, **even to an empty string**, and the lists are **never merged**. Merging would make the effective state a function of two sources read together, and would remove the ability to switch a module back *on* from the environment during an incident.

## What a disabled module loses

Filtering happens in `PackageManifest::getManifest()`, so a package is cut from discovery whole — **service providers and facade aliases together**. Filtering `providers()` alone would leave a dangling alias behind.

With an empty disabled list the manifest is returned untouched and `ModuleRegistry` is never read, so an application configuring neither channel behaves exactly as it did on 1.1.0.

## Module declarations

Read from the module's own `composer.json`, because they are needed *before* any service provider registers:

- `extra.true-modular.disablable: false` — this module must never be switched off.
- `extra.true-modular.owns: [...]` — vendor packages this module solely owns; they leave discovery with it. Without this, disabling a wrapper leaves the wrapped engine booting its own provider and migrations. `extra.laravel.dont-discover` cannot do this job: it is unconditional, so re-enabling the module in development would leave the engine undiscovered.

## Disabling never cascades

Switching off a module an enabled one depends on is an **error** naming exactly what to add. A silent cascade would let one line of configuration disable a dozen modules with no trace. Computing the cascade belongs to a UI that can show the affected set and ask for confirmation; the runtime always receives an explicit, complete list.

## `module:check`

Four validations: orphaned module directories; unknown names in the disabled list; `disablable: false` violations; enabled-depends-on-disabled and contested `owns`. Exit 0 with a summary, or 1 with one line per problem. **Run it on deploy before serving traffic** — a bad list must abort the release, not surface as a missing class on the first request.

`module:list` gains a `Status` column, an `enabled` flag in JSON, and `--only-disabled`.

## Notes

- **Additive only — please tag as `1.2.0`, not `2.0.0`.** Nothing is removed or changed; a host with neither channel configured is byte-identical to 1.1.0.
- `KernelServiceProvider` switches `ModuleRegistry` to `singletonIf` so the manifest, the provider sorter and the console commands share one instance and the module scan happens once. Under the stock Illuminate `Application` it still binds as before.
- Documented in `docs/switching-modules-off.md`, the README, `docs/cli-commands.md`, and both Laravel Boost resources.

Pint, PHPStan and 242 tests green.
