### PR TITLE
fix: keep getProvider() answering after boot has sorted the providers

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -149,7 +149,10 @@ final class Application extends FoundationApplication
             return;
         }
 
-        // Sort service providers according to module dependency order
+        // Sort service providers according to module dependency order. The sorter returns them
+        // re-keyed by class name, which is what this assignment needs: `markAsRegistered()` files
+        // providers under that key and `getProvider()` reads them back by it, so a list here would
+        // silently make every `getProvider()` call in the application answer null.
         $sorter = $this->resolve(ServiceProviderSorter::class);
         $this->serviceProviders = $sorter->sort($this->serviceProviders);
 

--- a/src/ServiceProviderSorter.php
+++ b/src/ServiceProviderSorter.php
@@ -33,8 +33,17 @@ final class ServiceProviderSorter
     /**
      * Sort service providers according to module dependency order.
      *
+     * The result is keyed by class name, the shape `Application::$serviceProviders` is read
+     * back through: `markAsRegistered()` files each provider under `get_class($provider)`
+     * and `getProvider()` is a plain lookup on that key. Returning a list here would leave
+     * `getProvider()` answering null for every provider in the application — silently, since
+     * a missing key is indistinguishable from a provider that was never registered.
+     *
+     * As in `markAsRegistered()`, one class means one provider: passing two instances of the
+     * same class keeps the last one.
+     *
      * @param  array<ServiceProvider>  $providers
-     * @return array<ServiceProvider>
+     * @return array<class-string<ServiceProvider>, ServiceProvider>
      *
      * @throws CircularDependencyException
      * @throws FilesystemException
@@ -72,8 +81,15 @@ final class ServiceProviderSorter
             $moduleProviders
         );
 
-        // Return other providers first, then sorted module providers
-        return [...$otherProviders, ...$sortedModuleProviders];
+        // Other providers first, then sorted module providers — re-keyed by class name on the
+        // way out, because the spread above would otherwise renumber them into a list.
+        $sorted = [];
+
+        foreach ([...$otherProviders, ...$sortedModuleProviders] as $provider) {
+            $sorted[$provider::class] = $provider;
+        }
+
+        return $sorted;
     }
 
     /**

--- a/tests/Doubles/UnmoduledServiceProvider.php
+++ b/tests/Doubles/UnmoduledServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\Tests\Doubles;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * A provider belonging to no module — the sorter's "other providers" bucket,
+ * which is what every framework and vendor provider falls into.
+ */
+final class UnmoduledServiceProvider extends ServiceProvider {}

--- a/tests/Unit/ApplicationProviderSortingTest.php
+++ b/tests/Unit/ApplicationProviderSortingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\Application;
+use Happenv\LaravelTrueModular\ServiceProviderSorter;
+use Happenv\LaravelTrueModular\Tests\Doubles\UnmoduledServiceProvider;
+use Illuminate\Support\ServiceProvider;
+use Myapp\Kernel\KernelModuleServiceProvider;
+use Myapp\Sale\SaleModuleServiceProvider;
+
+/**
+ * A modular application over the fixture modules, with three providers registered in
+ * an order the sorter has to undo: the module that sorts last, then a provider owned
+ * by no module, then the module that sorts first.
+ */
+$bootFixtureApplication = static function (): Application {
+    $app = new Application(dirname(appModulesFixture()));
+
+    $app->register(new SaleModuleServiceProvider($app));
+    $app->register(new UnmoduledServiceProvider($app));
+    $app->register(new KernelModuleServiceProvider($app));
+
+    $app->boot();
+
+    return $app;
+};
+
+it('answers getProvider() after boot, because sorting reorders the array without rekeying it', function () use ($bootFixtureApplication): void {
+    // `markAsRegistered()` stores providers under `get_class($provider)` and `getProvider()` is a
+    // plain lookup on that key — so anything that hands `$serviceProviders` back as a LIST makes
+    // every `getProvider()` call in the application answer null, silently and for all providers,
+    // module and framework alike. Assigning the sorter's result in `boot()` used to do exactly that.
+    $app = $bootFixtureApplication();
+
+    expect($app->getProvider(SaleModuleServiceProvider::class))->toBeInstanceOf(SaleModuleServiceProvider::class)
+        ->and($app->getProvider(KernelModuleServiceProvider::class))->toBeInstanceOf(KernelModuleServiceProvider::class)
+        ->and($app->getProvider(UnmoduledServiceProvider::class))->toBeInstanceOf(UnmoduledServiceProvider::class);
+});
+
+it('hands back the very instance it booted, not a second one built on the way out', function () use ($bootFixtureApplication): void {
+    // `getProvider()` returning *something* is not enough: callers reach for it to talk to the
+    // provider that ran, so identity is the property under test.
+    $app = $bootFixtureApplication();
+
+    $registered = $app->getProviders(SaleModuleServiceProvider::class);
+
+    expect($app->getProvider(SaleModuleServiceProvider::class))->toBe(reset($registered));
+});
+
+it('still orders module providers by dependency, behind the providers that belong to no module', function () use ($bootFixtureApplication): void {
+    // The guard on the fix above: preserving keys must not cost the ordering the sorter exists for.
+    // `myapp/sale` depends on `myapp/kernel` transitively, and it was registered first on purpose.
+    //
+    // Only the tail is asserted: the constructor registers Laravel's own base providers (events,
+    // log, routing) ahead of anything this test hands over, and those are the other half of the
+    // claim — they belong to no module, so they sort into the same leading bucket.
+    $app = $bootFixtureApplication();
+
+    $booted = array_values(array_map(
+        static fn (ServiceProvider $provider): string => $provider::class,
+        (fn (): array => $this->serviceProviders)->call($app),
+    ));
+
+    expect(array_slice($booted, -3))->toBe([
+        UnmoduledServiceProvider::class,
+        KernelModuleServiceProvider::class,
+        SaleModuleServiceProvider::class,
+    ]);
+});
+
+it('keys its result by class name, so the result can be assigned back over a class-keyed array', function (): void {
+    // Stated at the sorter itself, since `boot()` is only the first caller that depends on it.
+    $app = new Application(dirname(appModulesFixture()));
+
+    $sorted = $app->make(ServiceProviderSorter::class)->sort([
+        new SaleModuleServiceProvider($app),
+        new UnmoduledServiceProvider($app),
+        new KernelModuleServiceProvider($app),
+    ]);
+
+    expect(array_keys($sorted))->toBe([
+        UnmoduledServiceProvider::class,
+        KernelModuleServiceProvider::class,
+        SaleModuleServiceProvider::class,
+    ]);
+});

--- a/tests/Unit/ApplicationProviderSortingTest.php
+++ b/tests/Unit/ApplicationProviderSortingTest.php
@@ -48,6 +48,21 @@ it('hands back the very instance it booted, not a second one built on the way ou
     expect($app->getProvider(SaleModuleServiceProvider::class))->toBe(reset($registered));
 });
 
+it('refuses to register a provider twice after boot, which is what its own getProvider() guard is for', function () use ($bootFixtureApplication): void {
+    // The one caller of `getProvider()` inside this package: `register()` opens with
+    // `if (($registered = $this->getProvider($provider)) && ! $force)`. With the keys gone that
+    // guard could never fire after boot, so a second `register()` built a SECOND instance, filed it
+    // under the class name the sort had just vacated, and — because the application is already
+    // booted — ran `initialize()` and `boot()` on it. MEASURED: two instances, where the whole
+    // point of the guard is one. Everything a provider does on the way up therefore happened twice.
+    $app = $bootFixtureApplication();
+
+    $again = $app->register(SaleModuleServiceProvider::class);
+
+    expect($app->getProviders(SaleModuleServiceProvider::class))->toHaveCount(1)
+        ->and($again)->toBe($app->getProvider(SaleModuleServiceProvider::class));
+});
+
 it('still orders module providers by dependency, behind the providers that belong to no module', function () use ($bootFixtureApplication): void {
     // The guard on the fix above: preserving keys must not cost the ordering the sorter exists for.
     // `myapp/sale` depends on `myapp/kernel` transitively, and it was registered first on purpose.

--- a/tests/fixtures/app-modules/kernel/src/KernelModuleServiceProvider.php
+++ b/tests/fixtures/app-modules/kernel/src/KernelModuleServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Myapp\Kernel;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Fixture provider for the `myapp/kernel` module — first in the fixture
+ * topological order, since kernel declares no dependencies.
+ */
+final class KernelModuleServiceProvider extends ServiceProvider {}

--- a/tests/fixtures/app-modules/sale/src/SaleModuleServiceProvider.php
+++ b/tests/fixtures/app-modules/sale/src/SaleModuleServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Myapp\Sale;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Fixture provider for the `myapp/sale` module — sorts after kernel, core and
+ * pim, so registering it first forces the sorter to actually move something.
+ */
+final class SaleModuleServiceProvider extends ServiceProvider {}


### PR DESCRIPTION
## The bug

`app()->getProvider(AnyServiceProvider::class)` returns `null` for **every** provider in an application running this package — module, vendor and framework alike — from the first boot onwards.

`Application::boot()` assigns the sorter's result straight over `$serviceProviders`:

```php
$this->serviceProviders = $sorter->sort($this->serviceProviders);
```

and `ServiceProviderSorter::sort()` rebuilt the array with a spread of its two buckets:

```php
return [...$otherProviders, ...$sortedModuleProviders];
```

A spread renumbers, so what came back was a list — keys `0, 1, 2, …`. Laravel files providers under `get_class($provider)` in `markAsRegistered()`, and `getProvider()` is a plain lookup on that key, so after boot every lookup misses.

Measured on a host application before the fix:

```
getProvider: false
first keys: [0,1,2]
```

The failure is silent in the worst way: a missing key is indistinguishable from a provider that was never registered, so callers read the `null` as "that module isn't installed" rather than as a bug. `getProviders()` (plural) kept working the whole time — it filters by `instanceof` and never touches the keys — which is why host applications have been quietly working around this.

## The fix

`sort()` re-keys by class name on the way out. That is exactly the key set it was handed: `markAsRegistered()` already allows one provider instance per class, so this restores the array's shape rather than inventing one. The ordering the sorter exists for is untouched.

## Tests

`tests/Unit/ApplicationProviderSortingTest.php` boots a modular application over the fixture modules with three providers registered in an order the sorter has to undo — a module that sorts last, a provider owned by no module, then the module that sorts first — and asserts:

- `getProvider()` answers for all three after `boot()`;
- it answers with the very instance that was booted, not a second one;
- the dependency ordering still holds (the guard: preserving keys must not cost the sort);
- `sort()` itself returns a class-keyed array.

Three of the four fail on `1.x`; the ordering guard passes there, as it should. Full suite: 246 passed. Pint and PHPStan clean.