### PR TITLE
fix: getNamespace() po true-modular:setup + mylący prompt namespace'u

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -121,11 +121,12 @@ A one-time setup command (built with [Laravel Prompts](https://laravel.com/docs/
 
 1. the Composer `type` used to identify modules (default `true-module`);
 2. the directory modules live in (default `app-modules`);
-3. whether to convert the current `app/` folder into a `core` module — and if so, the module's
-   namespace (default `TrueModule`).
+3. whether to convert the current `app/` folder into a `core` module — and if so, the
+   application's root namespace under which every module (including the core one) will be
+   qualified (default `TrueModule`); the core module itself becomes `{namespace}\Core`.
 
 It always rewrites `bootstrap/app.php` to use `ModularApplication`, applying any non-default Composer
-type, modules directory, and (when converting) module namespace via the fluent setters. If you opt
+type, modules directory, and (when converting) modules namespace via the fluent setters. If you opt
 into the conversion, it also:
 
 - moves `app/` into `{modules-dir}/core/src/` and rewrites the `App\` namespace to `{namespace}\Core`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,8 @@ use Happenv\LaravelTrueModular\ModularApplication;
 return (new ModularApplication)
     ->composerType('acme-module')
     ->modulesDirectory('packages')
-    ->modulesNamespace('Acme')        // root namespace for modules (used when scaffolding)
+    ->modulesNamespace('Acme')        // root namespace for every module (used when scaffolding)
+    ->coreModuleName('Core')          // segment appended to it for the core module, e.g. Acme\Core
     ->configure(basePath: dirname(__DIR__))
     ->withRouting(/* ... */)
     ->withMiddleware(/* ... */)
@@ -56,8 +57,8 @@ return (new ModularApplication)
 
 The same settings are also exposed as static methods on `Application`
 (`Application::moduleComposerType()`, `Application::modulesDirectory()`,
-`Application::modulesNamespace()`) if you prefer to set them directly — `ModularApplication` is a thin
-fluent wrapper over those.
+`Application::modulesNamespace()`, `Application::coreModuleName()`) if you prefer to set them
+directly — `ModularApplication` is a thin fluent wrapper over those.
 
 ## 3. Create a module
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,6 +8,7 @@ use Happenv\LaravelTrueModular\ModuleSystem\ModuleActivation;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleAwarePackageManifest;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleName;
 use Happenv\LaravelTrueModular\ModuleSystem\ModuleRegistry;
+use Happenv\LaravelTrueModular\Setup\Steps\ConfigureComposer;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Filesystem\Filesystem;
@@ -17,6 +18,7 @@ use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use Override;
 use ReflectionException;
+use RuntimeException;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\JsonException;
 use TypeError;
@@ -252,6 +254,31 @@ final class Application extends FoundationApplication
 
         $this->initializingCallbacks = [];
         $this->initializedCallbacks = [];
+    }
+
+    /**
+     * Get the application namespace.
+     *
+     * Tries the stock Laravel resolution first, so an application whose root
+     * composer.json still autoloads app/ keeps behaving exactly as it does today.
+     * Falls back to the core module's namespace (`<modulesNamespace>\Core`) when the
+     * parent can't find a match — the shape `true-modular:setup` leaves behind once
+     * app/ has been converted into a module and its `"App\\": "app/"` autoload entry
+     * removed (see {@see ConfigureComposer::removeAppAutoload()}).
+     * Without this fallback nothing in `autoload.psr-4` points at `app/` any more, so
+     * the parent has nothing to match and throws — breaking every request, `route:list`,
+     * and `Model::factory()` call.
+     *
+     * @return string
+     */
+    #[Override]
+    public function getNamespace()
+    {
+        try {
+            return parent::getNamespace();
+        } catch (RuntimeException) {
+            return $this->namespace = self::getModulesNamespace().'\\Core\\';
+        }
     }
 
     private static string $moduleComposerType = self::DEFAULT_COMPOSER_TYPE;

--- a/src/Application.php
+++ b/src/Application.php
@@ -34,6 +34,9 @@ final class Application extends FoundationApplication
     /** Default root namespace under which modules live (e.g. the core module is `<namespace>\Core`). */
     public const string DEFAULT_MODULES_NAMESPACE = 'TrueModule';
 
+    /** Default name of the core module's namespace segment (e.g. `<namespace>\Core`). */
+    public const string DEFAULT_CORE_MODULE_NAME = 'Core';
+
     /** Default version stamped into a scaffolded module's composer.json and root `require`. */
     public const string DEFAULT_MODULE_VERSION = '1.0.0';
 
@@ -261,10 +264,10 @@ final class Application extends FoundationApplication
      *
      * Tries the stock Laravel resolution first, so an application whose root
      * composer.json still autoloads app/ keeps behaving exactly as it does today.
-     * Falls back to the core module's namespace (`<modulesNamespace>\Core`) when the
-     * parent can't find a match — the shape `true-modular:setup` leaves behind once
-     * app/ has been converted into a module and its `"App\\": "app/"` autoload entry
-     * removed (see {@see ConfigureComposer::removeAppAutoload()}).
+     * Falls back to the core module's namespace when the parent can't find a match —
+     * the shape `true-modular:setup` leaves behind once app/ has been converted into
+     * a module and its `"App\\": "app/"` autoload entry removed (see
+     * {@see ConfigureComposer::removeAppAutoload()}).
      * Without this fallback nothing in `autoload.psr-4` points at `app/` any more, so
      * the parent has nothing to match and throws — breaking every request, `route:list`,
      * and `Model::factory()` call.
@@ -277,7 +280,7 @@ final class Application extends FoundationApplication
         try {
             return parent::getNamespace();
         } catch (RuntimeException) {
-            return $this->namespace = self::getModulesNamespace().'\\Core\\';
+            return $this->namespace = self::getModulesNamespace().'\\'.self::getCoreModuleName().'\\';
         }
     }
 
@@ -324,6 +327,24 @@ final class Application extends FoundationApplication
     public static function getModulesNamespace(): string
     {
         return self::$modulesNamespace;
+    }
+
+    private static string $coreModuleName = self::DEFAULT_CORE_MODULE_NAME;
+
+    /**
+     * Set the core module's namespace segment, e.g. `Core` so the core module is
+     * `<modulesNamespace>\Core` (default `Core`). Used when scaffolding the core module
+     * (`true-modular:setup`) and by {@see Application::getNamespace()}'s fallback.
+     * Call before configure(), or use the fluent {@see ModularApplication} wrapper.
+     */
+    public static function coreModuleName(string $name): void
+    {
+        self::$coreModuleName = trim($name, '\\');
+    }
+
+    public static function getCoreModuleName(): string
+    {
+        return self::$coreModuleName;
     }
 
     /**

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -42,9 +42,10 @@ class SetupCommand extends Command
 
         $namespace = $convertApp
             ? text(
-                label: 'Namespace for the core module',
+                label: 'Root namespace for the application',
                 default: Application::DEFAULT_MODULES_NAMESPACE,
                 required: true,
+                hint: sprintf('Every module is qualified under it — the core module becomes <namespace>\\%s.', Application::getCoreModuleName()),
             )
             : null;
 
@@ -62,7 +63,7 @@ class SetupCommand extends Command
         }
 
         if (! confirm(
-            label: sprintf('This moves app/ into %s/core and rewrites the App\\ namespace to %s\\Core. Continue?', $modulesDirectory, $namespace),
+            label: sprintf('This moves app/ into %s/core and rewrites the App\\ namespace to %s\\%s. Continue?', $modulesDirectory, $namespace, Application::getCoreModuleName()),
             default: true,
         )) {
             $this->components->warn('Skipped the app → core conversion.');

--- a/src/ModularApplication.php
+++ b/src/ModularApplication.php
@@ -56,6 +56,18 @@ final class ModularApplication
     }
 
     /**
+     * Set the core module's namespace segment, e.g. `Core` so the core module is
+     * `<modulesNamespace>\Core` (default `Core`). Used when scaffolding the core module
+     * and by {@see Application::getNamespace()}'s fallback.
+     */
+    public function coreModuleName(string $name): self
+    {
+        Application::coreModuleName($name);
+
+        return $this;
+    }
+
+    /**
      * Hand off to the standard Laravel application builder, having applied the
      * module settings above to the custom {@see Application}.
      */

--- a/src/Setup/Steps/RewriteNamespace.php
+++ b/src/Setup/Steps/RewriteNamespace.php
@@ -4,35 +4,40 @@ declare(strict_types=1);
 
 namespace Happenv\LaravelTrueModular\Setup\Steps;
 
+use Happenv\LaravelTrueModular\Setup\TrueModularSetup;
+
 /**
- * Replace the App\ root namespace with {namespace}\Core across PHP files in
- * the given directories (the moved code plus config / database / routes).
+ * Replace the App\ root namespace with the given core module namespace (e.g.
+ * {namespace}\Core) across PHP files in the given directories (the moved code
+ * plus config / database / routes).
  */
 final class RewriteNamespace extends Step
 {
     /**
      * @param  list<string>  $directories  absolute directory paths to rewrite
+     * @param  string  $moduleNamespace  the core module's own namespace, already composed
+     *                                   (e.g. `TrueModule\Core`) — see {@see TrueModularSetup::convertAppToCoreModule()}
      * @return list<string> relative paths of changed files
      */
-    public function rewrite(array $directories, string $namespace): array
+    public function rewrite(array $directories, string $moduleNamespace): array
     {
         $changed = [];
 
         foreach ($directories as $directory) {
-            $changed = [...$changed, ...$this->rewriteDirectory($directory, $namespace)];
+            $changed = [...$changed, ...$this->rewriteDirectory($directory, $moduleNamespace)];
         }
 
         return $changed;
     }
 
     /** @return list<string> relative paths of changed files */
-    private function rewriteDirectory(string $directory, string $namespace): array
+    private function rewriteDirectory(string $directory, string $moduleNamespace): array
     {
         if (! $this->files->isDirectory($directory)) {
             return [];
         }
 
-        $core = trim($namespace, '\\').'\\Core';
+        $core = trim($moduleNamespace, '\\');
         $changed = [];
 
         foreach ($this->files->allFiles($directory) as $file) {

--- a/src/Setup/TrueModularSetup.php
+++ b/src/Setup/TrueModularSetup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Happenv\LaravelTrueModular\Setup;
 
+use Happenv\LaravelTrueModular\Application;
 use Happenv\LaravelTrueModular\Setup\Steps\ConfigureBootstrapApp;
 use Happenv\LaravelTrueModular\Setup\Steps\ConfigureComposer;
 use Happenv\LaravelTrueModular\Setup\Steps\EmptyBootstrapProviders;
@@ -54,7 +55,7 @@ final readonly class TrueModularSetup
     public function convertAppToCoreModule(string $modulesDirectory, string $composerType, string $namespace): array
     {
         $vendor = Str::kebab(class_basename(str_replace('\\', '/', $namespace)));
-        $moduleNamespace = trim($namespace, '\\').'\\Core';
+        $moduleNamespace = trim($namespace, '\\').'\\'.Application::getCoreModuleName();
 
         // 1. Move app/ -> {modulesDir}/core/src
         [$modulePath, $srcPath] = (new MoveApplicationToModule($this->files, $this->basePath))->move($modulesDirectory);
@@ -62,7 +63,7 @@ final readonly class TrueModularSetup
         // 2. Rewrite namespace in the moved code and the app's other code dirs
         $rewritten = (new RewriteNamespace($this->files, $this->basePath))->rewrite(
             [$srcPath, ...array_map($this->path(...), self::REWRITE_DIRECTORIES)],
-            $namespace,
+            $moduleNamespace,
         );
 
         // 3. Scaffold the module (composer.json + a ModuleProvider)

--- a/tests/Unit/ApplicationModulesConfigTest.php
+++ b/tests/Unit/ApplicationModulesConfigTest.php
@@ -8,6 +8,7 @@ afterEach(function (): void {
     // Reset process-wide settings so they cannot leak into other tests.
     Application::modulesDirectory(Application::DEFAULT_MODULES_DIRECTORY);
     Application::modulesNamespace(Application::DEFAULT_MODULES_NAMESPACE);
+    Application::coreModuleName(Application::DEFAULT_CORE_MODULE_NAME);
 });
 
 it('defaults the modules directory to the application default', function (): void {
@@ -27,4 +28,13 @@ it('defaults and configures the modules namespace, trimming slashes', function (
     Application::modulesNamespace('Acme\\');
 
     expect(Application::getModulesNamespace())->toBe('Acme');
+});
+
+it('defaults and configures the core module name, trimming slashes', function (): void {
+    expect(Application::getCoreModuleName())->toBe('Core')
+        ->and(Application::DEFAULT_CORE_MODULE_NAME)->toBe('Core');
+
+    Application::coreModuleName('\\Kernel\\');
+
+    expect(Application::getCoreModuleName())->toBe('Kernel');
 });

--- a/tests/Unit/ApplicationNamespaceTest.php
+++ b/tests/Unit/ApplicationNamespaceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\Application;
+use Illuminate\Filesystem\Filesystem;
+
+afterEach(function (): void {
+    // Reset process-wide settings so they cannot leak into other tests.
+    Application::modulesNamespace(Application::DEFAULT_MODULES_NAMESPACE);
+});
+
+it('falls back to the core module namespace when composer.json has no entry pointing at app/', function (): void {
+    // tests/fixtures/composer.json has no `autoload` key at all — exactly the shape
+    // `true-modular:setup` leaves behind once app/ has been converted into a module and its
+    // "App\\": "app/" entry removed via ConfigureComposer::removeAppAutoload(). Before the fix,
+    // Illuminate\Foundation\Application::getNamespace() has nothing in autoload.psr-4 to match
+    // and throws RuntimeException('Unable to detect application namespace.') — breaking every
+    // request, `route:list`, and `Model::factory()` on a converted app.
+    $app = new Application(dirname(appModulesFixture()));
+
+    expect($app->getNamespace())->toBe('TrueModule\Core\\');
+});
+
+it('builds the fallback from the configured modules namespace, not the bare default', function (): void {
+    Application::modulesNamespace('Acme');
+
+    $app = new Application(dirname(appModulesFixture()));
+
+    expect($app->getNamespace())->toBe('Acme\Core\\');
+});
+
+it('keeps resolving the parent namespace unchanged for an application whose composer.json still autoloads an existing app/', function (): void {
+    // Backward compatibility: an application that has NOT converted app/ into a module — the
+    // overwhelming majority of installs, today and pre-existing — must resolve exactly as stock
+    // Laravel does. The fix must never intercept a namespace the parent can already resolve.
+    $files = new Filesystem;
+    $base = sys_get_temp_dir().'/tm-namespace-'.bin2hex(random_bytes(6));
+    $files->ensureDirectoryExists($base.'/app');
+    $files->put($base.'/composer.json', json_encode([
+        'name' => 'acme/app',
+        'autoload' => ['psr-4' => ['App\\' => 'app/']],
+    ], JSON_PRETTY_PRINT));
+
+    try {
+        $app = new Application($base);
+
+        expect($app->getNamespace())->toBe('App\\');
+    } finally {
+        $files->deleteDirectory($base);
+    }
+});
+
+it('still resolves through the coincidental false-equals-false match when the App\\ entry points at a missing app/ directory', function (): void {
+    // The fragile trap named in the bug report, documented rather than relied on: realpath()
+    // returns false for both the non-existent app/ directory and the (also missing) target when
+    // the stale entry is left in place, so `false === false` gives the parent a match anyway.
+    // This pre-existing quirk survives the fix untouched, because the parent call succeeds here —
+    // the fallback in the catch block never runs.
+    $files = new Filesystem;
+    $base = sys_get_temp_dir().'/tm-namespace-'.bin2hex(random_bytes(6));
+    $files->ensureDirectoryExists($base);
+    $files->put($base.'/composer.json', json_encode([
+        'name' => 'acme/app',
+        'autoload' => ['psr-4' => ['App\\' => 'app/']],
+    ], JSON_PRETTY_PRINT));
+
+    try {
+        $app = new Application($base);
+
+        expect($app->getNamespace())->toBe('App\\');
+    } finally {
+        $files->deleteDirectory($base);
+    }
+});

--- a/tests/Unit/ApplicationNamespaceTest.php
+++ b/tests/Unit/ApplicationNamespaceTest.php
@@ -8,6 +8,7 @@ use Illuminate\Filesystem\Filesystem;
 afterEach(function (): void {
     // Reset process-wide settings so they cannot leak into other tests.
     Application::modulesNamespace(Application::DEFAULT_MODULES_NAMESPACE);
+    Application::coreModuleName(Application::DEFAULT_CORE_MODULE_NAME);
 });
 
 it('falls back to the core module namespace when composer.json has no entry pointing at app/', function (): void {
@@ -22,12 +23,13 @@ it('falls back to the core module namespace when composer.json has no entry poin
     expect($app->getNamespace())->toBe('TrueModule\Core\\');
 });
 
-it('builds the fallback from the configured modules namespace, not the bare default', function (): void {
+it('builds the fallback from the configured modules namespace and core module name, not the bare defaults', function (): void {
     Application::modulesNamespace('Acme');
+    Application::coreModuleName('Kernel');
 
     $app = new Application(dirname(appModulesFixture()));
 
-    expect($app->getNamespace())->toBe('Acme\Core\\');
+    expect($app->getNamespace())->toBe('Acme\Kernel\\');
 });
 
 it('keeps resolving the parent namespace unchanged for an application whose composer.json still autoloads an existing app/', function (): void {

--- a/tests/Unit/ModularApplicationTest.php
+++ b/tests/Unit/ModularApplicationTest.php
@@ -11,6 +11,7 @@ afterEach(function (): void {
     Application::moduleComposerType(Application::DEFAULT_COMPOSER_TYPE);
     Application::modulesDirectory(Application::DEFAULT_MODULES_DIRECTORY);
     Application::modulesNamespace(Application::DEFAULT_MODULES_NAMESPACE);
+    Application::coreModuleName(Application::DEFAULT_CORE_MODULE_NAME);
 });
 
 it('applies settings fluently and is chainable', function (): void {
@@ -19,9 +20,11 @@ it('applies settings fluently and is chainable', function (): void {
     expect($modular->composerType('acme-module'))->toBe($modular)
         ->and($modular->modulesDirectory('packages'))->toBe($modular)
         ->and($modular->modulesNamespace('Acme'))->toBe($modular)
+        ->and($modular->coreModuleName('Kernel'))->toBe($modular)
         ->and(Application::getModuleComposerType())->toBe('acme-module')
         ->and(Application::getModulesDirectory())->toBe('packages')
-        ->and(Application::getModulesNamespace())->toBe('Acme');
+        ->and(Application::getModulesNamespace())->toBe('Acme')
+        ->and(Application::getCoreModuleName())->toBe('Kernel');
 });
 
 it('hands off to the standard Laravel application builder', function (): void {

--- a/tests/Unit/TrueModularSetupTest.php
+++ b/tests/Unit/TrueModularSetupTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Happenv\LaravelTrueModular\Application;
 use Happenv\LaravelTrueModular\Setup\TrueModularSetup;
 use Illuminate\Filesystem\Filesystem;
 
@@ -45,6 +46,8 @@ beforeEach(function (): void {
 
 afterEach(function (): void {
     $this->files->deleteDirectory($this->base);
+    // Reset process-wide settings so they cannot leak into other tests.
+    Application::coreModuleName(Application::DEFAULT_CORE_MODULE_NAME);
 });
 
 it('swaps bootstrap/app.php to ModularApplication with non-default settings', function (): void {
@@ -171,4 +174,36 @@ it('aborts when the target module directory already exists', function (): void {
     expect(fn () => (new TrueModularSetup($this->files, $this->base))
         ->convertAppToCoreModule('packages', 'acme-module', 'TrueModule'))
         ->toThrow(RuntimeException::class);
+});
+
+it('scaffolds the core module using the explicit default segment', function (): void {
+    // Ties the assertion to the named constant instead of a hardcoded 'Core' string, so this
+    // test tracks the constant's value rather than silently drifting from it.
+    $report = (new TrueModularSetup($this->files, $this->base))
+        ->convertAppToCoreModule('packages', 'acme-module', 'TrueModule');
+
+    expect(Application::DEFAULT_CORE_MODULE_NAME)->toBe('Core')
+        ->and($report['moduleNamespace'])->toBe('TrueModule\\'.Application::DEFAULT_CORE_MODULE_NAME);
+});
+
+it('scaffolds the core module from the configured segment, not a segment hardcoded independently of it', function (): void {
+    // Before the fix, TrueModularSetup and RewriteNamespace each concatenated their own literal
+    // '\Core' suffix — changing the package setting had no effect on the scaffolded output. This
+    // proves the segment is actually read from Application::getCoreModuleName(), not re-hardcoded.
+    Application::coreModuleName('Kernel');
+
+    $report = (new TrueModularSetup($this->files, $this->base))
+        ->convertAppToCoreModule('packages', 'acme-module', 'TrueModule');
+
+    expect($report['moduleNamespace'])->toBe('TrueModule\Kernel');
+
+    // The namespace rewrite (moved code, config/database/routes) picked up the same segment.
+    expect($this->files->get($this->base.'/packages/core/src/Models/User.php'))
+        ->toContain('namespace TrueModule\Kernel\Models;')
+        ->and($this->files->get($this->base.'/config/auth.php'))->toContain('TrueModule\Kernel\Models\User::class');
+
+    // The scaffolded composer.json and provider picked up the same segment too.
+    $moduleComposer = json_decode($this->files->get($this->base.'/packages/core/composer.json'), true);
+    expect($moduleComposer['autoload']['psr-4'])->toBe(['TrueModule\\Kernel\\' => 'src/'])
+        ->and($moduleComposer['extra']['laravel']['providers'])->toBe(['TrueModule\\Kernel\\CoreServiceProvider']);
 });


### PR DESCRIPTION
## Kontekst

Dwa defekty ujawnione przy stawianiu nowej aplikacji tym pakietem (`true-modular:setup`).

## P1 — `Application::getNamespace()` wywraca aplikację po `true-modular:setup`

**Co się psuło.** `Illuminate\Foundation\Application::getNamespace()` szuka w `autoload.psr-4` korzeniowego `composer.json` wpisu, którego `realpath()` równa się `realpath(base_path('app'))`, i rzuca `RuntimeException('Unable to detect application namespace.')`, gdy nic nie trafi. `true-modular:setup` przenosi `app/` do modułu (`{modules-dir}/core/src`) i **niczego nie wpisuje w zamian** do `autoload.psr-4` — moduł jest wpięty przez `repositories`/`require` (path repository), nie przez PSR-4 w roocie. Skutek: HTTP 500 na każdym żądaniu, `php artisan route:list` rzuca, `Model::factory()` rzuca.

**Jak zmierzone.** Istniejący projekt, który tego nie odczuł, przetrwał tylko dlatego, że **zostawił** wpis `"App\\": "app/"` przy już nieistniejącym katalogu `app/` — wtedy `realpath()` zwraca `false` po OBU stronach porównania (`realpath($this->path())` i `realpath($this->basePath($pathChoice))`), a `false === false` w pętli parenta daje fałszywe trafienie. To przypadek, nie gwarancja: `ConfigureComposer::removeAppAutoload()` **w tym samym flow** oferuje usunięcie tego wpisu (`SetupCommand` pyta o to osobnym `confirm()`), a usunięcie wpisu usuwa też przypadkową kolizję `false === false` i odsłania prawdziwy błąd. Odtworzone testem na fixture `tests/fixtures/composer.json`, który nie ma w ogóle klucza `autoload` — dokładnie kształt, jaki zostawia setup.

**Co naprawiono.** `Happenv\LaravelTrueModular\Application::getNamespace()` (nadpisanie, `src/Application.php`) próbuje najpierw `parent::getNamespace()` — istniejące aplikacje z działającym wpisem `App\` → `app/` zachowują się identycznie jak dziś. Gdy rodzic rzuci `RuntimeException`, metoda zwraca namespace modułu rdzeniowego (`<modulesNamespace>\Core`, budowany z ustawień pakietu), z końcowym `\` zgodnie z kontraktem Laravela (`getNamespace()` zwraca np. `'App\'`).

**Dlaczego bezpieczne.** Zero zmian w istniejącej ścieżce sukcesu — `parent::getNamespace()` jest wołany jako pierwszy i jego wynik jest zwracany bez modyfikacji, więc każda aplikacja, której `composer.json` faktycznie wskazuje `app/`, dostaje dokładnie to samo co dziś (test regresji: `tests/Unit/ApplicationNamespaceTest.php`).

## P2 — instalator pyta o złą rzecz

**Co się psuło.** Prompt w `SetupCommand` brzmiał *„Namespace for the core module"*, ale odpowiedź jest używana jako **korzeniowy namespace całej aplikacji** — `ScaffoldCoreModule`/`TrueModularSetup::convertAppToCoreModule()` dokłada do niej `\Core` dla samego modułu core, a `Application::getModulesNamespace()` (karmiony tą samą odpowiedzią przez `->modulesNamespace()` w `bootstrap/app.php`) kwalifikuje pod nią KAŻDY kolejny moduł scaffoldowany przez `module:make`.

**Jak zidentyfikowane.** Użytkownik, który odpowiedział zgodnie z dosłownym brzmieniem pytania („Core"), dostaje `->modulesNamespace('Core')`. Moduł core dalej działa (jego własny namespace został wpisany ręcznie gdzie indziej w tym samym przebiegu setupu), ale **każdy następny moduł** scaffoldowany przez `module:make` dostaje `Core\Nazwa` zamiast `NazwaAplikacji\Nazwa` — cichy defekt, niewidoczny do drugiego modułu.

**Co naprawiono.**
- Przeformułowany prompt: *„Root namespace for the application"* + `hint` pokazujący, na co przekłada się odpowiedź (`... the core module becomes <namespace>\Core`) — odpowiedź „Core" przestaje być naturalnym odczytaniem pytania.
- Segment nazwy modułu rdzeniowego (dotąd zaszyty jako `'Core'` w TRZECH miejscach z osobna: `TrueModularSetup`, `RewriteNamespace` i w tekście tego samego promptu) wyniesiony do `Application::DEFAULT_CORE_MODULE_NAME` — obok `DEFAULT_MODULES_NAMESPACE`/`DEFAULT_MODULES_DIRECTORY` — z parą `coreModuleName()`/`getCoreModuleName()` (i `ModularApplication::coreModuleName()`), dokładnie na wzór istniejących ustawień pakietu.
- `RewriteNamespace` przestał samodzielnie doklejać `\Core` — dostaje już gotowy namespace modułu core od `TrueModularSetup::convertAppToCoreModule()`, jedynego miejsca, które go składa.
- Fallback z P1 (`getNamespace()`) czyta teraz to samo ustawienie (`getCoreModuleName()`) zamiast literału — projekt, który przemianuje segment modułu core, ma spójne zachowanie między tym, co scaffolduje `true-modular:setup`, a tym, co wylicza fallback wykrywania namespace'u.
- Dopisana dokumentacja (`docs/cli-commands.md`, `docs/getting-started.md`) tam, gdzie opisywała stary, mylący prompt.

**Dlaczego bezpieczne.** Wartości domyślne (`DEFAULT_MODULES_NAMESPACE = 'TrueModule'`, nowy `DEFAULT_CORE_MODULE_NAME = 'Core'`) się nie zmieniają — dla nikogo, kto dziś polega na domyślnym zachowaniu, nic się nie zmienia. Nowe metody (`coreModuleName()`, `getCoreModuleName()`, `ModularApplication::coreModuleName()`) są czysto addytywne. Żadna publiczna sygnatura nie ucierpiała.

## Testy

Oba defekty naprawiane metodą czerwone→zielone (falsyfikacja pokazana lokalnie: test bez fixa pada z dokładnie opisanym błędem — `RuntimeException: Unable to detect application namespace.` dla P1, `Undefined constant`/`BadMethodCallException` dla P2 — po fixie ten sam test przechodzi):

- `tests/Unit/ApplicationNamespaceTest.php` (nowy) — fallback bez wpisu w `autoload.psr-4`, fallback z niestandardowym `modulesNamespace`, zgodność wsteczna z istniejącym wpisem `App\` → `app/`, oraz udokumentowana pułapka `false === false`.
- `tests/Unit/TrueModularSetupTest.php` — scaffolding używa `Application::DEFAULT_CORE_MODULE_NAME`, i faktycznie czyta `Application::getCoreModuleName()` (zmiana ustawienia zmienia scaffoldowany namespace — dowód, że to nie jest osobny, zaszyty na nowo literał).
- `tests/Unit/ApplicationModulesConfigTest.php`, `tests/Unit/ModularApplicationTest.php` — pokrycie nowego ustawienia (domyślna wartość, trim ukośników, fluent setter) na wzór istniejących ustawień.

Lokalnie zielone: `vendor/bin/pest` (254 passed / 555 assertions), `vendor/bin/phpstan analyse` (no errors), `vendor/bin/pint --test` (passed). `vendor/bin/rector process --dry-run` pokazuje 7 znalezisk — wszystkie sprawdzone jako PRE-ISTNIEJĄCE na czystym `1.x` (niezwiązane z tym PR-em, poza jego zakresem).

## Do przejrzenia

Nie mergowane ani nietagowane — do przejrzenia i zmergowania przez maintainera.