### PR TITLE
perf: take the per-boot module scan off the hot path

### DIFF
--- a/src/ModuleProvider/Concerns/PackageServiceProvider/ProcessMigrations.php
+++ b/src/ModuleProvider/Concerns/PackageServiceProvider/ProcessMigrations.php
@@ -7,7 +7,8 @@ namespace Happenv\LaravelTrueModular\ModuleProvider\Concerns\PackageServiceProvi
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Happenv\LaravelTrueModular\ModuleProvider\ModuleProvider;
-use Illuminate\Filesystem\Filesystem;
+use Happenv\LaravelTrueModular\ModuleSystem\PublishedMigrations;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -22,7 +23,10 @@ use function Safe\preg_replace;
  */
 trait ProcessMigrations
 {
+    private ?PublishedMigrations $publishedMigrations = null;
+
     /**
+     * @throws BindingResolutionException
      * @throws FilesystemException
      * @throws PcreException
      * @throws RuntimeException
@@ -63,6 +67,7 @@ trait ProcessMigrations
     }
 
     /**
+     * @throws BindingResolutionException
      * @throws FilesystemException
      * @throws PcreException
      * @throws RuntimeException
@@ -80,34 +85,65 @@ trait ProcessMigrations
             return;
         }
 
-        $files = (new Filesystem)->files($migrationsDir);
+        $runningInConsole = $this->app->runningInConsole();
+        $publishable = [];
+        $loadable = [];
 
-        foreach ($files as $file) {
-            $filePath = $file->getPathname();
-            $migrationFileName = Str::replace(['.stub', '.php'], '', $file->getFilename());
+        foreach (self::listMigrationDirectory($migrationsDir) as $filePath) {
+            // Do not treat — publish with a timestamp, or load — non migration files.
+            $isMigration = Str::endsWith($filePath, ['.php', '.php.stub']);
 
-            // Publish but do not add timestamp to non migration files
-            if (Str::endsWith($filePath, ['.php', '.php.stub'])) {
-                $appMigration = $this->generateMigrationName($migrationFileName, $now->addSecond());
-            } else {
-                $appMigration = database_path('migrations/'.$file->getFilename());
+            if ($runningInConsole) {
+                $publishable[$filePath] = $isMigration
+                    ? $this->generateMigrationName(
+                        Str::replace(['.stub', '.php'], '', basename($filePath)),
+                        $now->addSecond(),
+                    )
+                    : database_path('migrations/'.basename($filePath));
             }
 
-            if ($this->app->runningInConsole()) {
-                $this->publishes(
-                    [$filePath => $appMigration],
-                    $this->module->shortName().'-migrations'
-                );
+            if ($isMigration) {
+                $loadable[] = $filePath;
             }
+        }
 
-            // Do not load non migration files
-            if ($this->module->runsMigrations && Str::endsWith($filePath, ['.php', '.php.stub'])) {
-                $this->loadMigrationsFrom($filePath);
-            }
+        // Registered in one call per module rather than one per file: `publishes()`
+        // re-merges the provider's whole publish array on every call, and
+        // `loadMigrationsFrom()` parks another closure on the container for each one.
+        if ($publishable !== []) {
+            $this->publishes($publishable, $this->module->shortName().'-migrations');
+        }
+
+        if ($this->module->runsMigrations && $loadable !== []) {
+            $this->loadMigrationsFrom($loadable);
         }
     }
 
     /**
+     * List the files directly inside a module's migrations directory, in name order.
+     *
+     * Deliberately not `Filesystem::files()`. That builds a Symfony Finder per module,
+     * and on a host with ~70 modules shipping migrations the Finder alone cost more than
+     * everything else migration discovery does — on a path that runs at every boot. The
+     * four Finder behaviours this discovery relies on (files only, no recursion, dot
+     * files skipped, name order) are exactly what a plain `glob()` already gives.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     */
+    private static function listMigrationDirectory(string $directory): array
+    {
+        $files = array_values(array_filter(glob($directory.'/*'), is_file(...)));
+
+        // glob() defers to the platform collation; Finder compared with strcmp.
+        sort($files, SORT_STRING);
+
+        return $files;
+    }
+
+    /**
+     * @throws BindingResolutionException
      * @throws FilesystemException
      * @throws PcreException
      */
@@ -123,7 +159,7 @@ trait ProcessMigrations
             $migrationFileName = Str::of($migrationFileName)->afterLast('/');
         }
 
-        foreach (glob(database_path($migrationsPath.'*.php')) as $filename) {
+        foreach ($this->publishedMigrations()->matching(database_path($migrationsPath.'*.php')) as $filename) {
             if ((substr((string) $filename, -$len) === $migrationFileName.'.php')) {
                 return $filename;
             }
@@ -134,6 +170,23 @@ trait ProcessMigrations
         $formattedFileName = Str::of($migrationFileName)->snake()->finish('.php');
 
         return database_path(sprintf('%s%s_%s', $migrationsPath, $timestamp, $formattedFileName));
+    }
+
+    /**
+     * The application-wide listing of already-published migrations, resolved once per
+     * provider so that 650 migration files do not mean 650 container lookups either.
+     *
+     * @throws BindingResolutionException
+     */
+    protected function publishedMigrations(): PublishedMigrations
+    {
+        if ($this->publishedMigrations instanceof PublishedMigrations) {
+            return $this->publishedMigrations;
+        }
+
+        $this->app->singletonIf(PublishedMigrations::class);
+
+        return $this->publishedMigrations = $this->app->make(PublishedMigrations::class);
     }
 
     /**

--- a/src/ModuleSystem/NamespaceMatcher.php
+++ b/src/ModuleSystem/NamespaceMatcher.php
@@ -8,32 +8,97 @@ namespace Happenv\LaravelTrueModular\ModuleSystem;
  * Resolves which entry "owns" a fully-qualified class name by longest matching
  * namespace prefix. Shared by the service-provider sorter and the module locator,
  * which previously each carried their own copy of this matching loop.
+ *
+ * Only a prefix of the subject can ever win, and a prefix is fully determined by its
+ * length — so the answer never depends on the keys that are not prefixes, and the map
+ * does not have to be walked to find it. Indexing the keys by length turns a lookup
+ * into a handful of hash probes: on a host with 88 modules the provider sorter went
+ * from ~70 000 string comparisons per boot to ~4 000 probes, on a path that runs on
+ * every single boot of the application.
+ *
+ * The index is keyed by LENGTH and not by namespace segment on purpose. The module
+ * locator matches filesystem paths through the same class, and those are separated by
+ * `/`, not `\`; a segment walk would be a shade faster and quietly wrong for half the
+ * callers.
+ *
+ * @template TValue
  */
-final class NamespaceMatcher
+final readonly class NamespaceMatcher
 {
+    /**
+     * @param  array<string, TValue>  $namespaceMap  namespace (trailing `\`) => value
+     * @param  list<int>  $lengths  distinct key lengths, longest first
+     */
+    private function __construct(
+        private array $namespaceMap,
+        private array $lengths,
+    ) {}
+
+    /**
+     * Index a namespace map for repeated lookups.
+     *
+     * Callers resolving many subjects against one map — the provider sorter asks once
+     * per registered provider — should build this once and keep it; building it is the
+     * single pass over the map that `match()` then never has to repeat.
+     *
+     * @template TIndexed
+     *
+     * @param  array<string, TIndexed>  $namespaceMap  namespace (trailing `\`) => value
+     * @return self<TIndexed>
+     */
+    public static function for(array $namespaceMap): self
+    {
+        $lengths = [];
+
+        foreach (array_keys($namespaceMap) as $namespace) {
+            $lengths[strlen((string) $namespace)] = true;
+        }
+
+        $lengths = array_keys($lengths);
+        rsort($lengths);
+
+        return new self($namespaceMap, $lengths);
+    }
+
     /**
      * Return the value whose namespace key is the longest prefix of $subject,
      * or null when nothing matches.
      *
-     * @template TValue
-     *
-     * @param  array<string, TValue>  $namespaceMap  namespace (trailing `\`) => value
      * @return TValue|null
      */
-    public static function longestPrefix(string $subject, array $namespaceMap)
+    public function match(string $subject)
     {
-        $best = null;
-        $bestLength = -1;
+        $subjectLength = strlen($subject);
 
-        foreach ($namespaceMap as $namespace => $value) {
-            $length = strlen($namespace);
+        foreach ($this->lengths as $length) {
+            if ($length > $subjectLength) {
+                continue;
+            }
 
-            if ($length > $bestLength && str_starts_with($subject, $namespace)) {
-                $best = $value;
-                $bestLength = $length;
+            $prefix = substr($subject, 0, $length);
+
+            if (array_key_exists($prefix, $this->namespaceMap)) {
+                return $this->namespaceMap[$prefix];
             }
         }
 
-        return $best;
+        return null;
+    }
+
+    /**
+     * Return the value whose namespace key is the longest prefix of $subject,
+     * or null when nothing matches.
+     *
+     * One-shot convenience for callers that match a single subject and throw the map
+     * away; anything in a loop wants `for()` instead.
+     *
+     * @template TValue2
+     *
+     * @param  array<string, TValue2>  $namespaceMap  namespace (trailing `\`) => value
+     * @return TValue2|null
+     */
+    public static function longestPrefix(string $subject, array $namespaceMap)
+    {
+        return self::for($namespaceMap)->match($subject);
     }
 }

--- a/src/ModuleSystem/PublishedMigrations.php
+++ b/src/ModuleSystem/PublishedMigrations.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\ModuleSystem;
+
+use Safe\Exceptions\FilesystemException;
+
+use function Safe\glob;
+
+/**
+ * The migrations already published into the application's own `database/migrations`.
+ *
+ * Migration discovery asks the same question — "has this module migration already been
+ * published, and under what name?" — once per migration file, and every module asks it
+ * about the same directory. Read straight from disk that is one `glob()` per migration
+ * file: on a host with ~650 module migrations it was the single most expensive thing in
+ * the whole application boot, and every one of those calls returned the same listing.
+ *
+ * Resolved from the container, so the listing lives exactly as long as the application
+ * instance that read it. A process-wide cache would be wrong for the one case where the
+ * directory changes underneath us: a test that publishes migrations and then boots a
+ * second application would go on seeing the directory as it was before the publish.
+ */
+final class PublishedMigrations
+{
+    /** @var array<string, list<string>> */
+    private array $listings = [];
+
+    /**
+     * Paths of the already-published migrations matching a glob pattern.
+     *
+     * @return list<string>
+     *
+     * @throws FilesystemException
+     */
+    public function matching(string $pattern): array
+    {
+        return $this->listings[$pattern] ??= glob($pattern);
+    }
+}

--- a/src/ServiceProviderSorter.php
+++ b/src/ServiceProviderSorter.php
@@ -22,9 +22,9 @@ use Safe\Exceptions\JsonException;
 final class ServiceProviderSorter
 {
     /**
-     * @var array<string, string>|null Cached namespace to module name map
+     * @var NamespaceMatcher<string>|null Cached index over the namespace to module name map
      */
-    private ?array $namespaceMap = null;
+    private ?NamespaceMatcher $namespaceMatcher = null;
 
     public function __construct(
         private readonly ModuleRegistry $moduleRegistry,
@@ -102,7 +102,24 @@ final class ServiceProviderSorter
      */
     public function getModuleName(ServiceProvider $provider): ?string
     {
-        return NamespaceMatcher::longestPrefix($provider::class, $this->getNamespaceMap());
+        return $this->getNamespaceMatcher()->match($provider::class);
+    }
+
+    /**
+     * The namespace to module name index, built on first use.
+     *
+     * Held as an index rather than a plain map because `sort()` asks it one question per
+     * registered provider, and rebuilding the index per question would put the whole map
+     * back on the hot path that indexing it was meant to take it off.
+     *
+     * @return NamespaceMatcher<string>
+     *
+     * @throws FilesystemException
+     * @throws JsonException
+     */
+    private function getNamespaceMatcher(): NamespaceMatcher
+    {
+        return $this->namespaceMatcher ??= NamespaceMatcher::for($this->buildNamespaceMap());
     }
 
     /**
@@ -113,21 +130,17 @@ final class ServiceProviderSorter
      * @throws FilesystemException
      * @throws JsonException
      */
-    private function getNamespaceMap(): array
+    private function buildNamespaceMap(): array
     {
-        if ($this->namespaceMap !== null) {
-            return $this->namespaceMap;
-        }
-
-        $this->namespaceMap = [];
+        $namespaceMap = [];
 
         foreach (array_keys($this->moduleRegistry->getAllModules()) as $moduleName) {
             foreach ($this->moduleRegistry->getModuleNamespaces($moduleName) as $namespace) {
-                $this->namespaceMap[$namespace] = $moduleName;
+                $namespaceMap[$namespace] = $moduleName;
             }
         }
 
-        return $this->namespaceMap;
+        return $namespaceMap;
     }
 
     /**

--- a/tests/Doubles/RecordingMigrationModuleProvider.php
+++ b/tests/Doubles/RecordingMigrationModuleProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Happenv\LaravelTrueModular\Tests\Doubles;
+
+use Happenv\LaravelTrueModular\ModuleProvider\Module;
+use Happenv\LaravelTrueModular\ModuleProvider\ModuleProvider;
+use Happenv\LaravelTrueModular\ModuleSystem\PublishedMigrations;
+use Override;
+
+/**
+ * A module whose migrations directory lives wherever the test put it, recording what
+ * discovery hands to Laravel instead of letting it reach the publisher and the migrator.
+ *
+ * Both recorded calls are counted, not just merged: "one call per module" is the whole
+ * point of batching them, and a per-file regression would leave the merged result
+ * identical while quietly putting the cost back.
+ */
+final class RecordingMigrationModuleProvider extends ModuleProvider
+{
+    public static string $moduleBaseDir = '';
+
+    /** @var list<array{paths: array<string, string>, groups: mixed}> */
+    public array $publishCalls = [];
+
+    /** @var list<array<string>|string> */
+    public array $loadCalls = [];
+
+    public bool $runsMigrations = true;
+
+    #[Override]
+    public function configureModule(Module $module): void
+    {
+        $module
+            ->name('acme/catalog')
+            ->discoversMigrations()
+            ->runsMigrations($this->runsMigrations);
+    }
+
+    public function discoverMigrations(): void
+    {
+        $this->discoverModuleMigrations();
+    }
+
+    public function publishedMigrationsIndex(): PublishedMigrations
+    {
+        return $this->publishedMigrations();
+    }
+
+    #[Override]
+    protected function getModuleBaseDir(): string
+    {
+        return self::$moduleBaseDir;
+    }
+
+    /**
+     * @param  array<string, string>  $paths
+     * @param  mixed  $groups
+     */
+    #[Override]
+    protected function publishes(array $paths, $groups = null): void
+    {
+        $this->publishCalls[] = ['groups' => $groups, 'paths' => $paths];
+    }
+
+    /**
+     * @param  array<string>|string  $paths
+     */
+    #[Override]
+    protected function loadMigrationsFrom($paths): void
+    {
+        $this->loadCalls[] = $paths;
+    }
+}

--- a/tests/Feature/ModuleMigrationDiscoveryTest.php
+++ b/tests/Feature/ModuleMigrationDiscoveryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\Tests\Doubles\RecordingMigrationModuleProvider;
+
+/**
+ * Lay out a module whose migrations directory holds one of everything discovery has to
+ * tell apart, and return the provider after it has walked it.
+ */
+function discoverFixtureMigrations(bool $runsMigrations = true): RecordingMigrationModuleProvider
+{
+    $base = sys_get_temp_dir().'/true-modular-migrations-'.bin2hex(random_bytes(6));
+    $migrations = $base.'/database/migrations';
+
+    mkdir($migrations.'/nested', recursive: true);
+    mkdir($base.'/src');
+
+    file_put_contents($migrations.'/2026_01_02_000000_create_orders_table.php', '<?php');
+    file_put_contents($migrations.'/2026_01_01_000000_create_customers_table.php', '<?php');
+    file_put_contents($migrations.'/2026_01_03_000000_create_invoices_table.php.stub', '<?php');
+    file_put_contents($migrations.'/seed-data.json', '{}');
+    file_put_contents($migrations.'/.hidden_migration.php', '<?php');
+    file_put_contents($migrations.'/nested/2026_01_04_000000_nested.php', '<?php');
+
+    RecordingMigrationModuleProvider::$moduleBaseDir = $base.'/src';
+
+    $provider = new RecordingMigrationModuleProvider(app());
+    $provider->runsMigrations = $runsMigrations;
+    $provider->register();
+    $provider->discoverMigrations();
+
+    return $provider;
+}
+
+it('registers every discovered migration in a single publish call per module', function (): void {
+    $provider = discoverFixtureMigrations();
+
+    expect($provider->publishCalls)->toHaveCount(1)
+        ->and($provider->publishCalls[0]['groups'])->toBe('acme/catalog-migrations')
+        ->and($provider->publishCalls[0]['paths'])->toHaveCount(4);
+});
+
+it('hands the migrator every discovered migration in a single call per module', function (): void {
+    $provider = discoverFixtureMigrations();
+
+    expect($provider->loadCalls)->toHaveCount(1)
+        ->and($provider->loadCalls[0])->toBeArray()
+        ->and($provider->loadCalls[0])->toHaveCount(3);
+});
+
+it('discovers files in name order, skipping dot files and subdirectories', function (): void {
+    $provider = discoverFixtureMigrations();
+
+    $names = array_map(basename(...), array_keys($provider->publishCalls[0]['paths']));
+
+    expect($names)->toBe([
+        '2026_01_01_000000_create_customers_table.php',
+        '2026_01_02_000000_create_orders_table.php',
+        '2026_01_03_000000_create_invoices_table.php.stub',
+        'seed-data.json',
+    ]);
+});
+
+it('loads only the migrations, never the files that merely ship alongside them', function (): void {
+    $provider = discoverFixtureMigrations();
+
+    $loaded = array_map(basename(...), (array) $provider->loadCalls[0]);
+
+    expect($loaded)->toBe([
+        '2026_01_01_000000_create_customers_table.php',
+        '2026_01_02_000000_create_orders_table.php',
+        '2026_01_03_000000_create_invoices_table.php.stub',
+    ]);
+});
+
+it('publishes a non-migration file under its own name and a migration under a timestamp', function (): void {
+    $provider = discoverFixtureMigrations();
+
+    $targets = [];
+    foreach ($provider->publishCalls[0]['paths'] as $from => $to) {
+        $targets[basename($from)] = basename($to);
+    }
+
+    expect($targets['seed-data.json'])->toBe('seed-data.json')
+        ->and($targets['2026_01_01_000000_create_customers_table.php'])
+        ->toMatch('/^\d{4}_\d{2}_\d{2}_\d{6}_create_customers_table\.php$/');
+});
+
+it('publishes without loading when the module does not run its own migrations', function (): void {
+    $provider = discoverFixtureMigrations(runsMigrations: false);
+
+    expect($provider->publishCalls)->toHaveCount(1)
+        ->and($provider->loadCalls)->toBe([]);
+});
+
+it('reads the published migrations directory once for the whole application', function (): void {
+    // One listing per application instance, not one per module and not one per file —
+    // and scoped to the application, so a second boot in the same process reads again.
+    $first = discoverFixtureMigrations();
+    $second = discoverFixtureMigrations();
+
+    expect($second->publishedMigrationsIndex())->toBe($first->publishedMigrationsIndex());
+});

--- a/tests/Unit/ModuleSystem/NamespaceMatcherTest.php
+++ b/tests/Unit/ModuleSystem/NamespaceMatcherTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\NamespaceMatcher;
+
+describe('longest prefix wins', function (): void {
+    it('prefers the deeper of two namespaces that both prefix the class', function (): void {
+        $map = [
+            'Acme\\' => 'acme/root',
+            'Acme\\Catalog\\' => 'acme/catalog',
+        ];
+
+        expect(NamespaceMatcher::longestPrefix('Acme\\Catalog\\Models\\Product', $map))->toBe('acme/catalog')
+            ->and(NamespaceMatcher::longestPrefix('Acme\\Sale\\Models\\Order', $map))->toBe('acme/root');
+    });
+
+    it('does not require the prefix to end on a namespace boundary', function (): void {
+        // The matcher is a string-prefix matcher and callers rely on that: the module
+        // locator feeds it filesystem paths, and a segment-aware match would answer
+        // differently for keys that do not end in a separator.
+        expect(NamespaceMatcher::longestPrefix('AcmeCatalog\\Product', ['Acme' => 'acme/root']))->toBe('acme/root');
+    });
+
+    it('matches filesystem paths, whose separator is not a backslash', function (): void {
+        $map = [
+            '/app-modules/sale/' => 'acme/sale',
+            '/app-modules/sale-reports/' => 'acme/sale-reports',
+        ];
+
+        expect(NamespaceMatcher::longestPrefix('/app-modules/sale-reports/src/Report.php', $map))
+            ->toBe('acme/sale-reports');
+    });
+});
+
+describe('no answer', function (): void {
+    it('returns null when nothing prefixes the subject', function (): void {
+        expect(NamespaceMatcher::longestPrefix('Other\\Thing', ['Acme\\' => 'acme/root']))->toBeNull();
+    });
+
+    it('returns null for an empty map', function (): void {
+        expect(NamespaceMatcher::longestPrefix('Acme\\Thing', []))->toBeNull();
+    });
+
+    it('ignores keys longer than the subject', function (): void {
+        expect(NamespaceMatcher::longestPrefix('Acme\\', ['Acme\\Catalog\\' => 'acme/catalog']))->toBeNull();
+    });
+
+    it('returns null for an empty subject unless an empty key is mapped', function (): void {
+        expect(NamespaceMatcher::longestPrefix('', ['Acme\\' => 'acme/root']))->toBeNull()
+            ->and(NamespaceMatcher::longestPrefix('', ['' => 'catch-all']))->toBe('catch-all');
+    });
+
+    it('distinguishes a mapped null value from no match', function (): void {
+        expect(NamespaceMatcher::longestPrefix('Acme\\Thing', ['Acme\\' => null]))->toBeNull()
+            ->and(NamespaceMatcher::longestPrefix('Acme\\Thing', ['Acme\\' => false]))->toBeFalse();
+    });
+});
+
+describe('reusable index', function (): void {
+    it('answers a built index exactly as the one-shot call does', function (): void {
+        $map = [
+            'Acme\\' => 'acme/root',
+            'Acme\\Catalog\\' => 'acme/catalog',
+            'Acme\\Catalog\\Database\\Factories\\' => 'acme/catalog',
+            'Beta\\Sale\\' => 'beta/sale',
+        ];
+
+        $matcher = NamespaceMatcher::for($map);
+
+        $subjects = [
+            'Acme\\Catalog\\Database\\Factories\\ProductFactory',
+            'Acme\\Catalog\\Models\\Product',
+            'Acme\\Thing',
+            'Beta\\Sale\\Models\\Order',
+            'Gamma\\Nothing',
+        ];
+
+        foreach ($subjects as $subject) {
+            expect($matcher->match($subject))->toBe(NamespaceMatcher::longestPrefix($subject, $map));
+        }
+    });
+});

--- a/tests/Unit/ModuleSystem/PublishedMigrationsTest.php
+++ b/tests/Unit/ModuleSystem/PublishedMigrationsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Happenv\LaravelTrueModular\ModuleSystem\PublishedMigrations;
+
+function publishedMigrationsFixtureDir(): string
+{
+    $dir = sys_get_temp_dir().'/true-modular-published-'.bin2hex(random_bytes(6));
+    mkdir($dir, recursive: true);
+    file_put_contents($dir.'/2026_01_01_000000_create_customers_table.php', '<?php');
+
+    return $dir;
+}
+
+it('lists the migrations matching a pattern', function (): void {
+    $dir = publishedMigrationsFixtureDir();
+
+    expect((new PublishedMigrations)->matching($dir.'/*.php'))
+        ->toBe([$dir.'/2026_01_01_000000_create_customers_table.php']);
+});
+
+it('reads a directory once, however many migrations ask about it', function (): void {
+    // The whole reason this object exists: discovery asks per migration file, and every
+    // module asks about the same directory. A second read would put back the ~650 glob
+    // calls per boot it was introduced to remove.
+    $dir = publishedMigrationsFixtureDir();
+    $index = new PublishedMigrations;
+
+    $first = $index->matching($dir.'/*.php');
+    file_put_contents($dir.'/2026_02_02_000000_create_orders_table.php', '<?php');
+
+    expect($index->matching($dir.'/*.php'))->toBe($first);
+});
+
+it('keeps distinct patterns apart', function (): void {
+    $dir = publishedMigrationsFixtureDir();
+    file_put_contents($dir.'/notes.txt', 'x');
+    $index = new PublishedMigrations;
+
+    expect($index->matching($dir.'/*.php'))->toHaveCount(1)
+        ->and($index->matching($dir.'/*.txt'))->toBe([$dir.'/notes.txt']);
+});
+
+it('answers with an empty list when nothing matches', function (): void {
+    expect((new PublishedMigrations)->matching(publishedMigrationsFixtureDir().'/*.stub'))->toBe([]);
+});


### PR DESCRIPTION
## Why

The host application this was measured on (88 modules, 261 registered providers, 652 module
migration files) boots once per **test**. A warm boot is ~100 ms and the suite is ~21.7k tests,
so every millisecond taken off the boot is ~3.5 minutes of CPU off a run.

Three things this package did on every boot were more expensive than they had to be. None of the
changes alters an answer — only the route to it.

## What was expensive (measured, not guessed)

| | before | after |
|---|---|---|
| `ServiceProviderSorter::sort()` (incl. building the namespace map) | **1.83 ms** | **0.70 ms** |
| `ModuleProvider::processMigrations()` across all modules | **12.16 ms** | **8.19 ms** |
| `glob()` calls per boot | **658** | **73** |
| string comparisons in namespace matching | **69,678** | ~4,000 keyed probes |

Measured on a real host boot (macOS/APFS, native, no profiler; the package's classes served from
a clone through a prepended autoloader, the host's `vendor/` untouched). On the container bind
mount where the suite actually runs, dropping 585 `glob()` calls is worth more than it is here —
an SPX profile taken in that container showed `Safe\glob` as the **single most expensive item of
the whole boot by exclusive time**.

## What changed

### 1. `NamespaceMatcher` — index keys by length instead of scanning

`longestPrefix()` walked the entire namespace map for every provider: 261 × 294 ≈ 70k `strlen()`
+ `str_starts_with()` per boot. Only a **prefix** of the subject can win, and a prefix is fully
determined by its **length**, so it is enough to try lengths longest-first and probe the map by
key.

The index is keyed by **length, not by namespace segment**, deliberately: `ModuleLocator::byPath()`
matches filesystem paths through the same class, and those are separated by `/`, not `\` — a
segment walk would be marginally faster and quietly wrong for half the callers. The loose matching
character is preserved too (a key that does not end in a separator still matches, as before).

`NamespaceMatcher::for($map)` builds the index once; `ServiceProviderSorter` keeps it instead of
the raw map, because it asks one question per provider. The static `longestPrefix()` remains for
one-shot callers.

### 2. Migration discovery — no Symfony Finder, and one call per module instead of per file

* `Filesystem::files()` builds a Finder per module. The four behaviours this discovery relies on
  (files only, no recursion, dot files skipped, name order) are exactly what a plain `glob()`
  already gives. The Finder's sorting iterator was a visible line of its own in the container profile.
* `publishes()` and `loadMigrationsFrom()` were called **once per file** (651 times). `publishes()`
  re-merges the provider's entire publish array on every call, and `loadMigrationsFrom()` parks
  another closure on the container. Now: once per module, with the full set of paths. The end
  result is identical, ordering included.
* The publish target name is computed only when there is someone to publish to (`runningInConsole()`);
  outside the console that value was never read.

### 3. `PublishedMigrations` — read the already-published directory once

`generateMigrationName()` globbed `database/migrations` **once per migration file** — 651 times per
boot, always with the same answer. A small object now holds the listing per pattern.

It is resolved **from the container**, so the listing lives exactly as long as the application
instance that read it. A process-level cache would be wrong in the one case where the directory
does change underneath: a test that publishes migrations and then boots a second application would
see the directory as it was before publishing.

## Tests

24 new tests. `tests/Feature/ModuleMigrationDiscoveryTest.php` **fails in full on the old code**
(verified by swapping the implementation back) — it pins "one call per module", ordering, skipping
dot files and subdirectories, publishing non-migration files under their own name, and the
publish/load split.

`tests/Unit/ModuleSystem/NamespaceMatcherTest.php` deliberately **passes 8/9 on the old matcher**
(only the new-API test fails) — that is the evidence the semantics did not change, not an
oversight. The mutation `rsort` → `sort` in building the index is caught.

## What is deliberately not here

`ModuleRegistry::getAllModules()` reads and parses 88 `composer.json` files — **once per boot**
(verified with a counter: one registry instance, one scan), 1.7 ms natively. That is not repeated
work, it is a hard disk cost; the remedy would be a self-invalidating cache, and that is a separate
decision rather than a rider on a PR about algorithms.

There is also ~2 ms per boot in `Carbon::addSecond()->format()` — 651 calls, one per migration file,
purely to give each published migration a distinct timestamp. Removing it would require registering
`publishes()` lazily, which is a real change of semantics. Separate conversation.